### PR TITLE
fix psycopg2 "can't adapt" error on save of a config. value from the admin pages.

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -13,6 +13,7 @@ from django.shortcuts import render_to_response
 from django.template.context import RequestContext
 from django.utils.formats import localize
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
 
 from constance import config, settings
 
@@ -72,7 +73,7 @@ class ConstanceAdmin(admin.ModelAdmin):
             form = ConstanceForm(request.POST)
             if form.is_valid():
                 form.save()
-                self.message_user(request, _('Live settings updated successfully.'))
+                self.message_user(request, ugettext('Live settings updated successfully.'))
                 return HttpResponseRedirect('.')
         context = {
             'config': [],


### PR DESCRIPTION
The config value was changed but the admin page throws a "can't adapt" error.
Swapped  the lazy ugettext call with a standard ugettext call to fix.
