### PR TITLE
Key field should be primary key to enforce uniqueness and prevent race conditions

### DIFF
--- a/constance/backends/database/models.py
+++ b/constance/backends/database/models.py
@@ -11,7 +11,7 @@ except ImportError:
                                "the constance database backend.")
 
 class Constance(models.Model):
-    key = models.TextField()
+    key = models.TextField(primary_key=True)
     value = PickledObjectField()
 
     class Meta:


### PR DESCRIPTION
Today we had a situation where a new setting (after deployment) was added twice to the database and resulted in a lot of errors. Making the `key` field the primary key enforces uniqueness on the database and prevents such situations from happening.
