### PR TITLE
Specifying a redis url in CONSTANCE_REDIS_CONNECTION

### DIFF
--- a/constance/backends/redisd.py
+++ b/constance/backends/redisd.py
@@ -25,7 +25,11 @@ class RedisBackend(Backend):
             except ImportError:
                 raise ImproperlyConfigured(
                     "The Redis backend requires redis-py to be installed.")
-            self._rd = redis.Redis(**settings.REDIS_CONNECTION)
+
+            if 'url' in settings.REDIS_CONNECTION:
+                self._rd = redis.from_url(settings.REDIS_CONNECTION['url'])
+            else:
+                self._rd = redis.Redis(**settings.REDIS_CONNECTION)
 
     def add_prefix(self, key):
         return "%s%s" % (self._prefix, key)


### PR DESCRIPTION
Allows the usage of configuration such as:

```
CONSTANCE_REDIS_CONNECTION = {
  'url': 'redis://localhost:6379'
}
```

This utilizes redis-py's creating a redis client from a url.
