### PR TITLE
Fixes "AttributeError: 'module' object has no attribute 'REDIS_PREFIX'" ...

### DIFF
--- a/constance/settings.py
+++ b/constance/settings.py
@@ -5,7 +5,7 @@ settings = import_module_attr(
     os.getenv('CONSTANCE_SETTINGS_MODULE', 'django.conf.settings')
 )
 
-PREFIX = getattr(settings, 'CONSTANCE_REDIS_PREFIX',
+REDIS_PREFIX = getattr(settings, 'CONSTANCE_REDIS_PREFIX',
          getattr(settings, 'CONSTANCE_PREFIX', 'constance:'))
 
 BACKEND = getattr(settings, 'CONSTANCE_BACKEND', 'constance.backends.redisd.RedisBackend')


### PR DESCRIPTION
...error when using the Redisd backend.

Caused by the latest change in e9d937b, in constance/backends/redisd.py, line 18.
