### PR TITLE
Robust key fetching

### DIFF
--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -37,10 +37,10 @@ class DatabaseBackend(Backend):
     def mget(self, keys):
         if not keys:
             return
-        prefixed_keys = [self.add_prefix(key) for key in keys]
-        stored = self._model._default_manager.filter(key__in=prefixed_keys)
-        for key, const in itertools.izip(keys, stored):
-            yield key, const.value
+        keys = dict((self.add_prefix(key), key) for key in keys)
+        stored = self._model._default_manager.filter(key__in=keys.keys())
+        for const in stored:
+            yield keys[const.key], const.value
 
     def get(self, key):
         key = self.add_prefix(key)


### PR DESCRIPTION
An alternate solution to #32 for fixing issue #31. Instead of some implicit key matching using `zip`, this explicitly matches keys to their values. Both the current implementation and #32 do not guarantee that the correct keys get matched, which is VERY dangerous.
