### PR TITLE
Hash settings to prevent overwriting of someone else's changes

### DIFF
--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -33,6 +33,14 @@
   <div id="content-main">
     <div class="module" id="changelist">
         <form id="changelist-form" action="" method="post">{% csrf_token %}
+            <ul class="errorlist">
+            {% for field in form.hidden_fields %}
+                {% for error in field.errors %}
+                  <li>(Hidden field {{ field.name }}) {{ error }}</li>
+                {% endfor %}
+                {{ field }}
+            {% endfor %}
+            </ul>
             <table cellspacing="0" id="result_list">
                 <thead>
                 <tr>


### PR DESCRIPTION
In a project where we are using django-constance, we have had serious problems with multiple users changing values.  

Problem:
- User A and B open the form
- User B makes changes and submits
- User A makes other changes and submits
- Only changes from User A are stored

Proposed Solution:
- Values are hashed and included in a hidden form field
- When validating the form, submitted hash is compared with actual hash; if the hashes are the same, the change is allowed, otherwise the changes are rejected (and user is notified to reload the form).

I don't know if the problem and solution are of added value to django-constance in general. For our use case, it is a must-have. There is no harm for us having to deploy a custom version. If you like the proposed solution, we can provide the necessary unit tests.
