### PR TITLE
Migration tweak to fix a failure in switching column types for key

### DIFF
--- a/constance/backends/database/migrations/0002_auto__chg_field_constance_key__add_unique_constance_key.py
+++ b/constance/backends/database/migrations/0002_auto__chg_field_constance_key__add_unique_constance_key.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
         # Changing field 'Constance.key'
         db.alter_column('constance_config', 'key',
                         self.gf('django.db.models.fields.CharField')(
-                            unique=True, max_length=255))
+                            max_length=255))
         # Adding unique constraint on 'Constance', fields ['key']
         db.create_unique('constance_config', ['key'])
 


### PR DESCRIPTION
I had an issue running this 0002 migration, until I made this tweak. Still seems to produce the correct field change and index creation.

Looked like it was trying to make the existing text column unique before changing to a character column, which bombed due to the proposed unique index not having a character size.
