### PR TITLE
Model Meta object_name. Fix for 1.6 admin

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -140,6 +140,7 @@ class ConstanceAdmin(admin.ModelAdmin):
 class Config(object):
     class Meta(object):
         app_label = 'constance'
+        object_name = 'Config'
         model_name = module_name = 'config'
         verbose_name_plural = 'config'
         get_ordered_objects = lambda x: False


### PR DESCRIPTION
Django 1.6 compatibility fix.
