### PR TITLE
Use app framework for initializing in Django 1.7, refs #64

### DIFF
--- a/constance/__init__.py
+++ b/constance/__init__.py
@@ -1,3 +1,8 @@
 from constance.config import Config
 
-config = Config()
+try:
+    from django.apps import AppConfig
+except ImportError:
+    config = Config()
+else:
+    default_app_config = 'constance.apps.ConstanceConfig'

--- a/constance/apps.py
+++ b/constance/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+from constance.config import Config
+
+
+class ConstanceConfig(AppConfig):
+    name = 'constance'
+    verbose_name = 'Constance'
+
+    def ready(self):
+        self.module.config = Config()


### PR DESCRIPTION
django-constance breaks in Django 1.7 with an `ImproperlyConfigured` exception. This is mainly due to checking for model installation too early. This patch adds an `AppConfig` object which instantiates the `Config` class only once Django's app installation is done.

In my tests it ran transparently in Django 1.6 and 1.7.
