### PR TITLE
Fixed AppRegistryNotReady exception on runserver on Django 1.7rc2.

### DIFF
--- a/constance/apps.py
+++ b/constance/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from constance.config import Config
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 class ConstanceConfig(AppConfig):
     name = 'constance'


### PR DESCRIPTION
Fixes issue #77.
