### PR TITLE
attempting a more elegant solution to detecting django version

### DIFF
--- a/constance/__init__.py
+++ b/constance/__init__.py
@@ -1,9 +1,6 @@
 import django
 
-major_version = django.VERSION[0]
-minor_version = django.VERSION[1]
-
-if major_version >= 1 and minor_version >= 7:
+if django.VERSION >= (1,7):
     from django.apps import AppConfig
     default_app_config = 'constance.apps.ConstanceConfig'
 else:


### PR DESCRIPTION
Never done this version check before, but this certainly seems like better logic than the comparable string comparison:

```
if django.get_version() >= "1.7.0":
   ...

```

Not sure if this will successfuly close: https://github.com/comoga/django-constance/issues/80, but it's a start I suppose!
