### PR TITLE
Update tox.ini to test for Django 1.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     django-picklefield
     django-17: Django>=1.7,<1.8
     django-18: Django>=1.8,<1.9
+    django-19: Django>=1.9,<1.10
     django-master: https://github.com/django/django/archive/master.tar.gz
 usedevelop = true
 commands =


### PR DESCRIPTION
I couldn't find anything relating to Django 1.9 support, since there's a stable release I thought let's add it to tox.ini explicitly.

https://docs.djangoproject.com/en/1.9/releases/1.9/
