### PR TITLE
separate configs in blocks (not break anything)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,3 +16,15 @@ If you have questions or have trouble using the app please file a bug report
 at:
 
 https://github.com/jezdez/django-constance/issues
+
+
+Changes - add block
+===================
+
+original:
+'USD_TO_MXN': (16.40, 'Dollar to mexican pesos'),
+
+new version:
+'USD_TO_MXN': (16.40, 'Dollar to mexican pesos', 'Finances' ),
+
+if adding third parameter "django constance" grouped the fields in a new block with the name of the third parameter

--- a/constance/admin.py
+++ b/constance/admin.py
@@ -130,7 +130,7 @@ class ConstanceAdmin(admin.ModelAdmin):
         for name, values in settings.CONFIG.items():
             default = values[0]
             help_text = values[1]
-            if len(values)==3:
+            if len(values) == 3:
                 type_item = values[2]
             else:
                 type_item = _('Default')
@@ -140,7 +140,7 @@ class ConstanceAdmin(admin.ModelAdmin):
             if value is None:
                 value = getattr(config, name)
             if type_item not in context['config_values']:
-                context['config_values'][type_item] = []   
+                context['config_values'][type_item] = []
             context['config_values'][type_item].append({
                 'name': name,
                 'default': localize(default),
@@ -149,7 +149,6 @@ class ConstanceAdmin(admin.ModelAdmin):
                 'modified': value != default,
                 'form_field': form[name],
             })
-        # context['config_values'].sort(key=itemgetter('name'))
         request.current_app = self.admin_site.name
         # compatibility to be removed when 1.7 is deprecated
         extra = {'current_app': self.admin_site.name} if VERSION < (1, 8) else {}

--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -38,10 +38,9 @@
 {% block content %}
   <div id="content-main">
     <form id="changelist-form" action="" method="post">{% csrf_token %}
-    {%for name,values in config_values.items%}
+    {% for name,values in config_values.items %}
         <h2>{{name}}</h2>
         <div class="module" id="changelist">
-            <!--<form id="changelist-form" action="" method="post">{% csrf_token %}-->
                 {% if form.errors %}
                 <ul class="errorlist">
                 {% endif %}
@@ -86,7 +85,7 @@
                     {% endfor %}
                 </table>
         </div>
-    {%endfor%}
+    {% endfor %}
     <br><hr>
     <input type="submit" name="_save" class="default" value="{% trans 'Save' %}"/>
     </form>

--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -37,56 +37,59 @@
 
 {% block content %}
   <div id="content-main">
-    <div class="module" id="changelist">
-        <form id="changelist-form" action="" method="post">{% csrf_token %}
-            {% if form.errors %}
-            <ul class="errorlist">
-            {% endif %}
-            {% for field in form.hidden_fields %}
-                {% for error in field.errors %}
-                  <li>{{ error }}</li>
+    <form id="changelist-form" action="" method="post">{% csrf_token %}
+    {%for name,values in config_values.items%}
+        <h2>{{name}}</h2>
+        <div class="module" id="changelist">
+            <!--<form id="changelist-form" action="" method="post">{% csrf_token %}-->
+                {% if form.errors %}
+                <ul class="errorlist">
+                {% endif %}
+                {% for field in form.hidden_fields %}
+                    {% for error in field.errors %}
+                      <li>{{ error }}</li>
+                    {% endfor %}
+                    {{ field }}
                 {% endfor %}
-                {{ field }}
-            {% endfor %}
-            {% if form.errors %}
-            </ul>
-            {% endif %}
-            <table cellspacing="0" id="result_list">
-                <thead>
-                <tr>
-                    <th><div class="text">{% trans "Name" %}</div></th>
-                    <th><div class="text">{% trans "Default" %}</div></th>
-                    <th><div class="text">{% trans "Value" %}</div></th>
-                    <th><div class="text">{% trans "Is modified" %}</div></th>
-                </tr>
-                </thead>
-                {% for item in config_values %}
-                <tr class="{% cycle 'row1' 'row2' %}">
-                    <th>{{ item.name }}
-                        <div class="help">{{ item.help_text|linebreaksbr }}</div>
-                    </th>
-                    <td>
-                        {{ item.default }}
-                    </td>
-                        <td>
-                            {{ item.form_field.errors }}
-                            {{ item.form_field }}
-                        </td>
-                    <td>
-                        {% if item.modified %}
-                            <img src="{% static 'admin/img/icon-yes.gif' %}" alt="{{ item.modified }}" />
-                        {% else %}
-                            <img src="{% static 'admin/img/icon-no.gif' %}" alt="{{ item.modified }}" />
-                        {% endif %}
-                    </td>
+                {% if form.errors %}
+                </ul>
+                {% endif %}
+                <table cellspacing="0" id="result_list">
+                    <thead>
+                    <tr>
+                        <th style='width:30%;'><div class="text">{% trans "Name" %}</div></th>
+                        <th style='width:30%;'><div class="text">{% trans "Default" %}</div></th>
+                        <th style='width:35%;'><div class="text">{% trans "Value" %}</div></th>
+                        <th style='width:5%;'><div class="text">{% trans "Is modified" %}</div></th>
                     </tr>
-                {% endfor %}
-            </table>
-            <p class="paginator">
-            <input type="submit" name="_save" class="default" value="{% trans 'Save' %}"/>
-            </p>
-        </form>
-    </div>
+                    </thead>
+                    {% for item in values %}
+                    <tr class="{% cycle 'row1' 'row2' %}">
+                        <th>{{ item.name }}
+                            <div class="help">{{ item.help_text|linebreaksbr }}</div>
+                        </th>
+                        <td>
+                            {{ item.default }}
+                        </td>
+                            <td>
+                                {{ item.form_field.errors }}
+                                {{ item.form_field }}
+                            </td>
+                        <td>
+                            {% if item.modified %}
+                                <img src="{% static 'admin/img/icon-yes.gif' %}" alt="{{ item.modified }}" />
+                            {% else %}
+                                <img src="{% static 'admin/img/icon-no.gif' %}" alt="{{ item.modified }}" />
+                            {% endif %}
+                        </td>
+                        </tr>
+                    {% endfor %}
+                </table>
+        </div>
+    {%endfor%}
+    <br><hr>
+    <input type="submit" name="_save" class="default" value="{% trans 'Save' %}"/>
+    </form>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
i think sometimes we need to make a block for differents types of values, for example, encapsulate finances values like tax and parity.

so, i modify the code for add this function without break the Backward compatibility.  new config looks like this:
 
CONSTANCE_CONFIG = {
    'TEST_1': (42, 'Answer to the Ultimate Question of Life, The Universe, and Everything'),
    'TEST_2': ('prueba', 'string test'),
    'TAX': (0.16, 'Tax','Finances'),
    'USD_TO_MXN': (16.40, 'Dollar to mexican pesos','Finances'),
}

where finances is the new block 
![Image](http://ronin2.ninja/wp-content/uploads/2015/11/django_constance.png)