### PR TITLE
Replace removed gif icons with svg versions

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -127,6 +127,7 @@ class ConstanceAdmin(admin.ModelAdmin):
             'opts': Config._meta,
             'form': form,
             'media': self.media + form.media,
+            'icon_type': 'gif' if VERSION < (1, 9) else 'svg',
         }
         for name, (default, help_text) in settings.CONFIG.items():
             # First try to load the value from the actual backend

--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -74,9 +74,9 @@
                         </td>
                     <td>
                         {% if item.modified %}
-                            <img src="{% static 'admin/img/icon-yes.gif' %}" alt="{{ item.modified }}" />
+                            <img src="{% static 'admin/img/icon-yes.'|add:icon_type %}" alt="{{ item.modified }}" />
                         {% else %}
-                            <img src="{% static 'admin/img/icon-no.gif' %}" alt="{{ item.modified }}" />
+                            <img src="{% static 'admin/img/icon-no.'|add:icon_type %}" alt="{{ item.modified }}" />
                         {% endif %}
                     </td>
                     </tr>


### PR DESCRIPTION
The new admin style for Django 1.9 has replaced its gif icons for svg versions.