### PR TITLE
Moved ConstanceForm to a property to make it exchangable by inheritance

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -112,6 +112,7 @@ class ConstanceForm(forms.Form):
 
 class ConstanceAdmin(admin.ModelAdmin):
     change_list_template = 'admin/constance/change_list.html'
+    change_list_form = ConstanceForm
 
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.module_name
@@ -134,9 +135,9 @@ class ConstanceAdmin(admin.ModelAdmin):
         # Then update the mapping with actually values from the backend
         initial = dict(default_initial,
             **dict(config._backend.mget(settings.CONFIG.keys())))
-        form = ConstanceForm(initial=initial)
+        form = self.change_list_form(initial=initial)
         if request.method == 'POST':
-            form = ConstanceForm(data=request.POST, initial=initial)
+            form = self.change_list_form(data=request.POST, initial=initial)
             if form.is_valid():
                 form.save()
                 # In django 1.5 this can be replaced with self.message_user

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,32 @@ setting to ``False`` and give the users or user groups access to the
 
    The virtual application ``Constance`` among your regular applications.
 
+Custom settings form
+--------------------
+
+If you aim at creating a custom settings form this is possible in the following
+way: You can inherit from ``ConstanceAdmin`` and set the ``form`` property on
+your custom admin to use your custom form. This allows you to define your own
+formsets and layouts, similar to defining a custom form on a standard
+Django ModelAdmin. This way you can fully style your settings form and group
+settings the way you like.
+
+.. code-block:: python
+
+    from constance.admin import ConstanceAdmin, ConstanceForm, Config
+    class CustomConfigForm(ConstanceForm):
+          def __init__(self, *args, **kwargs):
+            super(CustomConfigForm, self).__init__(*args, **kwargs)
+            #... do stuff to make your settings form nice ...
+
+    class ConfigAdmin(ConstanceAdmin):
+        form = CustomConfigForm
+        change_list_template = 'admin/config/settings.html'
+
+    admin.site.unregister([Config])
+    admin.site.register([Config], ConfigAdmin)
+
+
 More documentation
 ------------------
 


### PR DESCRIPTION
I moved the form class for constance to a property of the Admin, similar to the form property in the default Model Admin, but gave it a different name in case the actual form will be used in some kind of detailed settings view in the future.
This allows to easily customize the Form used by Constance for rendering the settings, by simply subclassing ConstanceAdmin and ConstanceForm.