### PR TITLE
Added CONSTANCE_IGNORE_ADMIN_VERSION_CHECK settings option to ignore …

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -103,6 +103,10 @@ class ConstanceForm(forms.Form):
 
     def clean_version(self):
         value = self.cleaned_data['version']
+
+        if settings.IGNORE_ADMIN_VERSION_CHECK:
+            return value
+
         if value != self.initial['version']:
             raise forms.ValidationError(_('The settings have been modified '
                                           'by someone else. Please reload the '

--- a/constance/settings.py
+++ b/constance/settings.py
@@ -24,3 +24,7 @@ REDIS_CONNECTION_CLASS = getattr(settings, 'CONSTANCE_REDIS_CONNECTION_CLASS',
 REDIS_CONNECTION = getattr(settings, 'CONSTANCE_REDIS_CONNECTION', {})
 
 SUPERUSER_ONLY = getattr(settings, 'CONSTANCE_SUPERUSER_ONLY', True)
+
+IGNORE_ADMIN_VERSION_CHECK = getattr(settings,
+                                     'CONSTANCE_IGNORE_ADMIN_VERSION_CHECK',
+                                     False)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,15 @@ admin will show.
 See the :ref:`Backends <backends>` section how to setup the backend and
 finish the configuration.
 
+``django-constance``'s hashes generated in different instances of the same
+application may differ, preventing data from being saved. 
+
+Use this option in order to skip hash verification.
+
+.. code-block:: python
+
+    CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
+
 Custom fields
 -------------
 


### PR DESCRIPTION
…the version protection. When you use django-constance on a cloud platform, with several machines, giving you problems by keeping the machine does not have to be the same which has served constant form.