### PR TITLE
Fix formatting of CONSTANCE_ADDITIONAL_FIELDS doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ You can set the field type by the third value in the `CONSTANCE_CONFIG`
 tuple. The value can be string or one of the supported types:
 
 .. code-block:: python
+
         'THE_ANSWER': (42, 'Answer to the Ultimate Question of Life, '
                                    'The Universe, and Everything', str),
 
@@ -77,17 +78,17 @@ If you can add your custom field types, you can use the
 use later evaluated strings instead of direct classes:
 
 .. code-block:: python
+
         CONSTANCE_ADDITIONAL_FIELDS = {
-           'yes_no_null_select': ['django.forms.fields.ChoiceField',
-              {
-              'widget': 'django.forms.Select',
-              'choices': (("-----", None), ("yes", "Yes"), ("no", "No"))
-              }],
+            'yes_no_null_select': ['django.forms.fields.ChoiceField', {
+                'widget': 'django.forms.Select',
+                'choices': (("-----", None), ("yes", "Yes"), ("no", "No"))
+            }],
         }
 
-       CONSTANCE_CONFIG = {
-           'MY_SELECT_KEY': ('yes', 'select yes or no', 'yes_no_null_select'),
-       }
+        CONSTANCE_CONFIG = {
+            'MY_SELECT_KEY': ('yes', 'select yes or no', 'yes_no_null_select'),
+        }
 
 Usage
 -----


### PR DESCRIPTION
Code examples aren't rendering currently on http://django-constance.readthedocs.org/en/latest/#custom-fields due to missing line at the start of code-blocks.