### PR TITLE
Make CONSTANCE_ADDITIONAL_FIELDS more flexible

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -47,7 +47,10 @@ FIELDS = {
 
 def parse_additional_fields(fields):
     for key in fields:
-        field = fields[key]
+        field = list(fields[key])
+
+        if len(field) == 1:
+            field.append({})
 
         field[0] = import_string(field[0])
 
@@ -57,6 +60,8 @@ def parse_additional_fields(fields):
 
             if 'widget_kwargs' in field[1]:
                 del field[1]['widget_kwargs']
+
+        fields[key] = field
 
     return fields
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,7 +95,7 @@ This is a mapping between a field label and a sequence (list or tuple).  The fir
 path of a field class, and the (optional) second item is a dictionary used to configure the field.
 
 The `widget` and `widget_kwargs` keys in the field config dictionary can be used to configure the widget used in admin,
- the other values will be passed as kwargs to the field's `__init__()`
+the other values will be passed as kwargs to the field's `__init__()`
 
 Note: Use later evaluated strings instead of direct classes for the field and widget classes:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,17 +65,39 @@ Use this option in order to skip hash verification.
 Custom fields
 -------------
 
-You can set the field type by the third value in the `CONSTANCE_CONFIG`
-tuple. The value can be string or one of the supported types:
+You can set the field type with the third value in the `CONSTANCE_CONFIG` tuple.
+
+The value can one of the supported types or a string matching a key in your :setting:`CONSTANCE_ADDITIONAL_FIELDS`
+
+The supported types are:
+
+* `bool`
+* `int`
+* `float`
+* `Decimal`
+* `long` (on python 2)
+* `str`
+* `unicode` (on python 2)
+* `datetime`
+* `date`
+* `time`
+
+For example, to force a value to be handled as a string:
 
 .. code-block:: python
 
         'THE_ANSWER': (42, 'Answer to the Ultimate Question of Life, '
                                    'The Universe, and Everything', str),
 
-If you can add your custom field types, you can use the
-`CONSTANCE_ADDITIONAL_FIELDS` variable. Note that you must
-use later evaluated strings instead of direct classes:
+Custom field types are supported using the dictionary :setting:`CONSTANCE_ADDITIONAL_FIELDS`.
+
+This is a mapping between a field label and a sequence (list or tuple).  The first item in the sequence is the string
+class path of a field class, and the (optional) second item is a dictionary used to configure the field.
+
+The `widget` and `widget_kwargs` keys in the field config dictionary can be used to configure the widget used in admin,
+ the other values will be passed as kwargs to the field's `__init__()`
+
+Note: Use later evaluated strings instead of direct classes for the field and widget classes:
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,7 +92,7 @@ For example, to force a value to be handled as a string:
 Custom field types are supported using the dictionary :setting:`CONSTANCE_ADDITIONAL_FIELDS`.
 
 This is a mapping between a field label and a sequence (list or tuple).  The first item in the sequence is the string
-class path of a field class, and the (optional) second item is a dictionary used to configure the field.
+path of a field class, and the (optional) second item is a dictionary used to configure the field.
 
 The `widget` and `widget_kwargs` keys in the field config dictionary can be used to configure the widget used in admin,
  the other values will be passed as kwargs to the field's `__init__()`

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -57,7 +57,9 @@ CONSTANCE_ADDITIONAL_FIELDS = {
          'widget': 'django.forms.Select',
          'choices': (("-----", None), ("yes", "Yes"), ("no", "No"))
          }],
-     }
+     # note this intentionally uses a tuple so that we can test immutable
+     'email': ('django.forms.fields.EmailField',),
+}
 
 CONSTANCE_CONFIG = {
     'INT_VALUE': (1, 'some int'),
@@ -73,6 +75,7 @@ CONSTANCE_CONFIG = {
     'TIME_VALUE': (time(23, 59, 59), 'And happy New Year'),
     'CHOICE_VALUE': ('yes', 'select yes or no', 'yes_no_null_select'),
     'LINEBREAK_VALUE': ('Spam spam', 'eggs\neggs'),
+    'EMAIL_VALUE': ('test@example.com', 'An email', 'email'),
 }
 
 DEBUG = True

--- a/tests/storage.py
+++ b/tests/storage.py
@@ -28,6 +28,8 @@ class StorageTestsMixin(object):
         self.assertEqual(self.config.DATE_VALUE, date(2010, 12, 24))
         self.assertEqual(self.config.TIME_VALUE, time(23, 59, 59))
         self.assertEqual(self.config.CHOICE_VALUE, 'yes')
+        self.assertEqual(self.config.EMAIL_VALUE, 'test@example.com')
+
 
         # set values
         self.config.INT_VALUE = 100
@@ -41,6 +43,7 @@ class StorageTestsMixin(object):
         self.config.DATE_VALUE = date(2001, 12, 20)
         self.config.TIME_VALUE = time(1, 59, 0)
         self.config.CHOICE_VALUE = 'no'
+        self.config.EMAIL_VALUE = 'foo@bar.com'
 
         # read again
         self.assertEqual(self.config.INT_VALUE, 100)
@@ -54,6 +57,8 @@ class StorageTestsMixin(object):
         self.assertEqual(self.config.DATE_VALUE, date(2001, 12, 20))
         self.assertEqual(self.config.TIME_VALUE, time(1, 59, 0))
         self.assertEqual(self.config.CHOICE_VALUE, 'no')
+        self.assertEqual(self.config.EMAIL_VALUE, 'foo@bar.com')
+
 
     def test_nonexistent(self):
         try:


### PR DESCRIPTION
Allow the field config to be a tuple, and allow the config dict to be omitted.