### PR TITLE
Typo on the variable name of verification hash version

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -109,7 +109,7 @@ class ConstanceForm(forms.Form):
     def clean_version(self):
         value = self.cleaned_data['version']
 
-        if settings.IGNORE_ADMIN_VERSION_CHECK:
+        if settings.CONSTANCE_IGNORE_ADMIN_VERSION_CHECK:
             return value
 
         if value != self.initial['version']:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ Use this option in order to skip hash verification.
 
 .. code-block:: python
 
-    IGNORE_ADMIN_VERSION_CHECK = True
+    CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
 
 Custom fields
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ Use this option in order to skip hash verification.
 
 .. code-block:: python
 
-    CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
+    IGNORE_ADMIN_VERSION_CHECK = True
 
 Custom fields
 -------------


### PR DESCRIPTION
The name of the variable has missing "CONSTANCE_" string at the begining