### PR TITLE
Undo last commit as it introduces an error

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -109,7 +109,7 @@ class ConstanceForm(forms.Form):
     def clean_version(self):
         value = self.cleaned_data['version']
 
-        if settings.CONSTANCE_IGNORE_ADMIN_VERSION_CHECK:
+        if settings.IGNORE_ADMIN_VERSION_CHECK:
             return value
 
         if value != self.initial['version']:


### PR DESCRIPTION
The last merged pull request #136  introduced an error, as in line 112 it used the prefixed version of `IGNORE_ADMIN_VERSION_CHECK` whereas it should used the one without prefix as defined in settings.py. Reverting the last commit fixes the error.