### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Django model backend built in) with an integration with the Django admin app.
 
 For more information see the documentation at:
 
-http://django-constance.readthedocs.org/
+https://django-constance.readthedocs.io/
 
 If you have questions or have trouble using the app please file a bug report
 at:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -60,7 +60,7 @@ v1.0 (2014/12/04)
 
 * Added docs and set up Read The Docs project:
 
-  http://django-constance.readthedocs.org/
+  https://django-constance.readthedocs.io/
 
 * Set up Transifex project for easier translations:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.