### PR TITLE
Update connection class string for django redis

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -56,7 +56,7 @@ If you are using `django-redis <http://niwibe.github.io/django-redis/>`_,
 feel free to use the ``CONSTANCE_REDIS_CONNECTION_CLASS`` setting to define
 a callable that returns a redis connection, e.g.::
 
-    CONSTANCE_REDIS_CONNECTION_CLASS = 'redis_cache.get_redis_connection'
+    CONSTANCE_REDIS_CONNECTION_CLASS = 'django_redis.get_redis_connection'
 
 ``CONSTANCE_REDIS_PREFIX``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`redis_cache` is deprecated, and updated to `django_redis` from version of 3.9.x
http://niwinz.github.io/django-redis/latest/