### PR TITLE
autofill cache if key is missing.

### DIFF
--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -61,6 +61,9 @@ class DatabaseBackend(Backend):
         key = self.add_prefix(key)
         if self._cache:
             value = self._cache.get(key)
+            if value is None:
+                self.autofill()
+                value = self._cache.get(key)
         else:
             value = None
         if value is None:


### PR DESCRIPTION
Hi,
all constance values are set into cache in autofill() method on the constance start. 
All values are set in the same time and their expires in the same time.
After constance cache expires, next time a code ask for constance value, the value is set back into cache.
So constance re-fills cache value be value, one be one, but it causes a lot of unnecessary db calls. 
I want to autofill all constance values into cache in the same time to save db queries. 
This problem is way more obvious when DATABASE_CACHE_AUTOFILL_TIMEOUT is very small. 
