### PR TITLE
Add django app config for "constance.backends.database"

### DIFF
--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -7,7 +7,7 @@ from .. import Backend
 from ... import settings, signals, config
 
 
-default_app_config = 'constance.backends.database.apps.ConstanceConfig'
+default_app_config = 'constance.backends.database.apps.ConstanceDatabaseConfig'
 
 
 class DatabaseBackend(Backend):

--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -7,6 +7,9 @@ from .. import Backend
 from ... import settings, signals, config
 
 
+default_app_config = 'constance.backends.database.apps.ConstanceConfig'
+
+
 class DatabaseBackend(Backend):
     def __init__(self):
         from .models import Constance

--- a/constance/backends/database/apps.py
+++ b/constance/backends/database/apps.py
@@ -2,7 +2,7 @@ from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 
 
-class ConstanceConfig(AppConfig):
+class ConstanceDatabaseConfig(AppConfig):
     name = 'constance.backends.database'
     label = 'constance_db'
     verbose_name = _('Constance Database Backend')

--- a/constance/backends/database/apps.py
+++ b/constance/backends/database/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class ConstanceConfig(AppConfig):
+    name = 'constance.backends.database'
+    label = 'constance_db'
+    verbose_name = _('Constance Database Backend')

--- a/constance/backends/database/migrations/0001_initial.py
+++ b/constance/backends/database/migrations/0001_initial.py
@@ -6,6 +6,8 @@ import picklefield.fields
 
 
 class Migration(migrations.Migration):
+    replaces = [('database', '0001_initial')]
+
     dependencies = []
 
     operations = [

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -89,7 +89,7 @@ make sure the data model is correctly created::
 
 Please make sure to apply the database migrations::
 
-    python manage.py migrate database
+    python manage.py migrate constance_db
 
 .. note:: If you're upgrading Constance to 1.0 and use Django 1.7 or higher
           please make sure to let the migration system know that you've
@@ -97,7 +97,7 @@ Please make sure to apply the database migrations::
 
           You can do that using the ``--fake`` option of the migrate command::
 
-              python manage.py migrate database --fake
+              python manage.py migrate constance_db --fake
 
 Just like the Redis backend you can set an optional prefix that is used during
 database interactions (it defaults to an empty string, ``''``). To use


### PR DESCRIPTION
It is not cool to have app "database" (default name is same as module name) in django registry.
