### PR TITLE
Facilitate renaming Constance in Admin

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 from collections import OrderedDict
 
 from django import forms, VERSION
+from django.apps import apps
 from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin import widgets
@@ -20,7 +21,7 @@ from django.utils.module_loading import import_string
 from django.utils.translation import ugettext_lazy as _
 
 
-from . import LazyConfig, settings, apps
+from . import LazyConfig, settings
 
 config = LazyConfig()
 
@@ -190,7 +191,9 @@ class ConstanceAdmin(admin.ModelAdmin):
                 return HttpResponseRedirect('.')
         context = {
             'config_values': [],
-            'title': _('Constance config'),
+            'title': _('{0} {1}'.format(
+                self.model._meta.app_config.verbose_name.title(),
+                self.model._meta.verbose_name_plural)),
             'app_label': 'constance',
             'opts': self.model._meta,
             'form': form,
@@ -255,12 +258,12 @@ class Config(object):
 
         def get_change_permission(self):
             return 'change_%s' % self.model_name
-        
+
         @property
         def app_config(self):
-            return apps.ConstanceConfig
+            return apps.get_app_config(self.app_label)
 
     _meta = Meta()
-    
+
 
 admin.site.register([Config], ConstanceAdmin)

--- a/constance/admin.py
+++ b/constance/admin.py
@@ -191,9 +191,7 @@ class ConstanceAdmin(admin.ModelAdmin):
                 return HttpResponseRedirect('.')
         context = {
             'config_values': [],
-            'title': _('{0} {1}'.format(
-                self.model._meta.app_config.verbose_name.title(),
-                self.model._meta.verbose_name_plural)),
+            'title': self.model._meta.app_config.verbose_name,
             'app_label': 'constance',
             'opts': self.model._meta,
             'form': form,

--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -75,7 +75,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ app_label|capfirst|escape }}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name|capfirst|escape }}</a>
   &rsaquo; {{ opts.verbose_name_plural|capfirst }}
 </div>
 {% endblock %}

--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -75,7 +75,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name|capfirst|escape }}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
   &rsaquo; {{ opts.verbose_name_plural|capfirst }}
 </div>
 {% endblock %}


### PR DESCRIPTION
An application user who wants to use an app under a different name would normally override the configuration. This is explained in the [Django documentation](https://docs.djangoproject.com/en/1.10/ref/applications/#for-application-users).

To use _Constance_ under the _Setup_ name, the following can be added to `apps.py`:
```python
## mysite/apps.py
import constance.apps

class RenameConstanceConfig(constance.apps.ConstanceConfig):
    verbose_name = 'Setup'
    verbose_name_plural = 'Setup'
```

This does not work as expected and will still leave _constance_ strings laying around since the config is [hard-coded](https://github.com/jazzband/django-constance/blob/dd173cd42cb9351285163fde5101975862c5ebfa/constance/admin.py#L261) and the _constance_ string is [hard-coded](https://github.com/jazzband/django-constance/blob/dd173cd42cb9351285163fde5101975862c5ebfa/constance/admin.py#L193) in some places. This patch addresses these issues and using the code above will work as expected.

This patch does the following changes:

* Instead of assuming the `app_config` is always going to be `ConstanceConfig`, load it dynamically. If the user overrides the config in their project, it will pick up the right config;
* Use `verbose_name` in `createlist_view` for `create_list` page title instead of static strings;
* Use `verbose_name` in `create_list.html` breadcrumbs. This is consistent with Django Admin [change_list.thml](https://github.com/django/django/blob/3c447b108ac70757001171f7a4791f493880bf5b/django/contrib/admin/templates/admin/change_list.html#L32)

