### PR TITLE
Propagate Django Admin customizations

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -189,15 +189,16 @@ class ConstanceAdmin(admin.ModelAdmin):
                     _('Live settings updated successfully.'),
                 )
                 return HttpResponseRedirect('.')
-        context = {
-            'config_values': [],
-            'title': self.model._meta.app_config.verbose_name,
-            'app_label': 'constance',
-            'opts': self.model._meta,
-            'form': form,
-            'media': self.media + form.media,
-            'icon_type': 'gif' if VERSION < (1, 9) else 'svg',
-        }
+        context = dict(
+            admin.site.each_context(request),
+            config_values=[],
+            title=self.model._meta.app_config.verbose_name,
+            app_label='constance',
+            opts=self.model._meta,
+            form=form,
+            media=self.media + form.media,
+            icon_type='gif' if VERSION < (1, 9) else 'svg',
+        )
         for name, options in settings.CONFIG.items():
             context['config_values'].append(
                 self.get_config_value(name, options, form, initial)


### PR DESCRIPTION
If the user of the application customizes various aspects of the Django Admin site through variables like `site_header`, `site_header`, etc. (see Django Admin [docs](https://docs.djangoproject.com/en/1.10/ref/contrib/admin/#adminsite-attributes)) these customizations get lost on the Constance Admin pages. Constance does not pick up these customizations and the Admin templates revert to defaults.

Django Admin includes a function called [`each_context`](https://github.com/django/django/blob/967be82443b5640d61608a89897d8ce2bc44fa54/django/contrib/admin/sites.py#L269) which:
> Returns a dictionary of variables to put in the template context for
> *every* page in the admin site.

This patch uses `each_context` when building the `context` for the `changelist_view` function. This way, Django Admin customizations get propagated to the Constance Admin pages.

This patch also changes the way the `context` dictionary is built, from using the `{}` syntax to using the `dict` syntax. The `dict` synatax facilitates the use of `each_context` directly when building the dictionary. This is consistent with its use in Django Admin, see [here](https://github.com/django/django/blob/0a63ef3f61f42c5fd22f2d0b626e386fd426ebed/django/contrib/admin/options.py#L1454), [here](https://github.com/django/django/blob/0a63ef3f61f42c5fd22f2d0b626e386fd426ebed/django/contrib/admin/options.py#L1628), and [here](https://github.com/django/django/blob/967be82443b5640d61608a89897d8ce2bc44fa54/django/contrib/admin/actions.py#L66).