### PR TITLE
Preserve line breaks in default value

### DIFF
--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -14,7 +14,7 @@
             {{ item.name }} <div class="help">{{ item.help_text|linebreaksbr }}</div>
         </th>
         <td>
-            {{ item.default }}
+            {{ item.default|linebreaks }}
         </td>
         <td>
             {{ item.form_field.errors }}


### PR DESCRIPTION
In the default value of a field is of type string and has line breaks (using `\n`), they are not preserved when the *Constance config* page is rendered in the Django Admin. This patch adds the [`linebreaks`](https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#linebreaks) filter to the template so that the newlines ('\n') are converted to line break ('\<br\>').