### PR TITLE
Additional fields fix

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -89,9 +89,9 @@ class ConstanceForm(forms.Form):
 
         for name, options in settings.CONFIG.items():
             default, help_text = options[0], options[1]
-            if len(options) == 3 and options[2] not in settings.ADDITIONAL_FIELDS:
+            if len(options) == 3:
                 config_type = options[2]
-                if not isinstance(options[0], config_type):
+                if config_type not in settings.ADDITIONAL_FIELDS and not isinstance(options[0], config_type):
                     raise ImproperlyConfigured(_("Default value type must be "
                                                  "equal to declared config "
                                                  "parameter type. Please fix "

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -134,7 +134,7 @@ Note: Use later evaluated strings instead of direct classes for the field and wi
         CONSTANCE_ADDITIONAL_FIELDS = {
             'yes_no_null_select': ['django.forms.fields.ChoiceField', {
                 'widget': 'django.forms.Select',
-                'choices': (("-----", None), ("yes", "Yes"), ("no", "No"))
+                'choices': ((None, "-----"), ("yes", "Yes"), ("no", "No"))
             }],
         }
 

--- a/example/cheeseshop/settings.py
+++ b/example/cheeseshop/settings.py
@@ -99,7 +99,7 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'django.forms.fields.ChoiceField',
         {
             'widget': 'django.forms.Select',
-            'choices': (("-----", None), ("yes", "Yes"), ("no", "No"))
+            'choices': ((None, "-----"), ("yes", "Yes"), ("no", "No"))
         }
     ],
     'email': ('django.forms.fields.EmailField',),

--- a/example/cheeseshop/settings.py
+++ b/example/cheeseshop/settings.py
@@ -94,11 +94,24 @@ CONSTANCE_REDIS_CONNECTION = {
     'db': 0,
 }
 
+CONSTANCE_ADDITIONAL_FIELDS = {
+    'yes_no_null_select': [
+        'django.forms.fields.ChoiceField',
+        {
+            'widget': 'django.forms.Select',
+            'choices': (("-----", None), ("yes", "Yes"), ("no", "No"))
+        }
+    ],
+    'email': ('django.forms.fields.EmailField',),
+}
+
 CONSTANCE_CONFIG = {
     'BANNER': ('The National Cheese Emporium', 'name of the shop'),
     'OWNER': ('Mr. Henry Wensleydale', 'owner of the shop'),
+    'OWNER_EMAIL': ('henry@example.com', 'contact email for owner', 'email'),
     'MUSICIANS': (4, 'number of musicians inside the shop'),
     'DATE_ESTABLISHED': (date(1972, 11, 30), "the shop's first opening"),
+    'MY_SELECT_KEY': ('yes', 'select yes or no', 'yes_no_null_select'),
 }
 
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -52,7 +52,7 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'django.forms.fields.ChoiceField',
         {
             'widget': 'django.forms.Select',
-            'choices': (("-----", None), ("yes", "Yes"), ("no", "No"))
+            'choices': ((None, "-----"), ("yes", "Yes"), ("no", "No"))
         }
     ],
     # note this intentionally uses a tuple so that we can test immutable

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,25 @@
+from constance.admin import ConstanceForm
+from django.forms import fields
+from django.test import TestCase
+
+
+class TestForm(TestCase):
+
+    def test_form_field_types(self):
+
+        f = ConstanceForm({})
+
+        self.assertIsInstance(f.fields['INT_VALUE'], fields.IntegerField)
+        self.assertIsInstance(f.fields['LONG_VALUE'], fields.IntegerField)
+        self.assertIsInstance(f.fields['BOOL_VALUE'], fields.BooleanField)
+        self.assertIsInstance(f.fields['STRING_VALUE'], fields.CharField)
+        self.assertIsInstance(f.fields['UNICODE_VALUE'], fields.CharField)
+        self.assertIsInstance(f.fields['DECIMAL_VALUE'], fields.DecimalField)
+        self.assertIsInstance(f.fields['DATETIME_VALUE'], fields.SplitDateTimeField)
+        self.assertIsInstance(f.fields['FLOAT_VALUE'], fields.FloatField)
+        self.assertIsInstance(f.fields['DATE_VALUE'], fields.DateField)
+        self.assertIsInstance(f.fields['TIME_VALUE'], fields.TimeField)
+
+        # from CONSTANCE_ADDITIONAL_FIELDS
+        self.assertIsInstance(f.fields['CHOICE_VALUE'], fields.ChoiceField)
+        self.assertIsInstance(f.fields['EMAIL_VALUE'], fields.EmailField)


### PR DESCRIPTION
- Don't ignore additional fields when creating form.  Fixes regression from 2f88a1bff2d3741cd18e1b47fe8c8c1d882795f4
- Added test of form field types
- Added CONSTANCE_ADDITIONAL_FIELDS to example app
- Updated ChoiceField example, the key & value seemed to be the wrong way around?