### PR TITLE
Add "Reset to default" feature

### DIFF
--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -6,7 +6,6 @@
             <th><div class="text">{% trans "Default" %}</div></th>
             <th><div class="text">{% trans "Value" %}</div></th>
             <th><div class="text">{% trans "Is modified" %}</div></th>
-            <th><div class="text">{% trans "Reset to default" %}</div></th>
         </tr>
     </thead>
     {% for item in config_values %}
@@ -20,6 +19,8 @@
         <td>
             {{ item.form_field.errors }}
             {{ item.form_field }}
+            <br>
+            <a href="#" onClick="document.getElementById('{{ item.form_field.auto_id }}').value = '{{ item.default|escapejs }}'; return false;">Reset to default</a>
         </td>
         <td>
             {% if item.modified %}
@@ -27,9 +28,6 @@
             {% else %}
                 <img src="{% static 'admin/img/icon-no.'|add:icon_type %}" alt="{{ item.modified }}" />
             {% endif %}
-        </td>
-        <td>
-             <a href="#" onClick="document.getElementById('{{ item.form_field.auto_id }}').value = '{{ item.default|escapejs }}'; return false;">Reset to default</a>
         </td>
     </tr>
     {% endfor %}

--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -6,6 +6,7 @@
             <th><div class="text">{% trans "Default" %}</div></th>
             <th><div class="text">{% trans "Value" %}</div></th>
             <th><div class="text">{% trans "Is modified" %}</div></th>
+            <th><div class="text">{% trans "Reset to default" %}</div></th>
         </tr>
     </thead>
     {% for item in config_values %}
@@ -26,6 +27,9 @@
             {% else %}
                 <img src="{% static 'admin/img/icon-no.'|add:icon_type %}" alt="{{ item.modified }}" />
             {% endif %}
+        </td>
+        <td>
+             <a href="#" onClick="document.getElementById('{{ item.form_field.auto_id }}').value = '{{ item.default|escapejs }}'; return false;">Reset to default</a>
         </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Fix for #178. The JavaScript is pretty basic:
```javascript
document.getElementById(...).value = ...
```
Here is how it looks:
![reset-do-default](https://cloud.githubusercontent.com/assets/241185/20770394/6c992202-b6fa-11e6-9eaa-1fb6051c21d1.png)
