### PR TITLE
Fix handling of MultiValueField's (eg SplitDateTimeField) on the command line. Fixes #186 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Jake Merdich <jmerdich@users.noreply.github.com>
 Jannis Leidel <jannis@leidel.info>
 Janusz Harkot <janusz.harkot@gmail.com>
 Jiri Barton <jbar@hosting4u.cz>
+John Carter <john@therefromhere.org>
 Jonas <jvp@jonasundderwolf.de>
 Kuba Zarzycki <jakubzarzycki@gmail.com>
 Leandra Finger <leandra.finger@gmail.com>

--- a/constance/management/commands/constance.py
+++ b/constance/management/commands/constance.py
@@ -39,7 +39,8 @@ class Command(BaseCommand):
 
         parser_set = subparsers.add_parser('set', cmd=self, help='set the value of a Constance key')
         parser_set.add_argument('key', help='name of the key to get', metavar='KEY')
-        parser_set.add_argument('value', help='value to set', metavar='VALUE')
+        # use nargs='+' so that we pass a list to MultiValueField (eg SplitDateTimeField)
+        parser_set.add_argument('value', help='value to set', metavar='VALUE', nargs='+')
 
     def handle(self, command, key=None, value=None, *args, **options):
 
@@ -51,6 +52,10 @@ class Command(BaseCommand):
 
         elif command == 'set':
             try:
+                if len(value) == 1:
+                    # assume that if a single argument was passed, the field doesn't expect a list
+                    value = value[0]
+
                 _set_constance_value(key, value)
             except KeyError as e:
                 raise CommandError(key + " is not defined in settings.CONSTANCE_CONFIG")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -273,6 +273,24 @@ Then setting an invalid date will fail as follow::
    CommandError: Enter a valid date.
 
 
+.. note::  If the admin fields is a `MultiValueField`, (e.g. datetime, which uses `SplitDateTimeField` by default)
+then the separate field values need to be provided as separate arguments.
+
+Eg, given this config::
+
+   CONSTANCE_CONFIG = {
+       'DATETIME_VALUE': (datetime(2010, 8, 23, 11, 29, 24), 'time of the first commit'),
+   }
+
+Then this works (and the quotes are optional)::
+
+   ./manage.py constance set DATETIME_VALUE '2011-09-24' '12:30:25'
+
+This doesn't work::
+
+   ./manage.py constance set DATETIME_VALUE '2011-09-24 12:30:25'
+   CommandError: Enter a list of values.
+
 Editing
 -------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
 from textwrap import dedent
 
 from django.core.management import call_command, CommandError
@@ -50,9 +51,9 @@ u"""        BOOL_VALUE	True
 
         self.assertEqual(config.EMAIL_VALUE, "blah@example.com")
 
-        call_command('constance', *('set', 'DATETIME_VALUE', '2011-09-24 12:30:25'), stdout=self.out)
+        call_command('constance', *('set', 'DATETIME_VALUE', '2011-09-24', '12:30:25'), stdout=self.out)
 
-        self.assertEqual(config.DATETIME_VALUE, "2011-09-24 12:30:25")
+        self.assertEqual(config.DATETIME_VALUE, datetime(2011, 9, 24, 12, 30, 25))
 
     def test_get_invalid_name(self):
         self.assertRaisesMessage(CommandError, "NOT_A_REAL_CONFIG is not defined in settings.CONSTANCE_CONFIG",
@@ -65,3 +66,7 @@ u"""        BOOL_VALUE	True
     def test_set_invalid_value(self):
         self.assertRaisesMessage(CommandError, "Enter a valid email address.",
                                  call_command, 'constance', 'set', 'EMAIL_VALUE', 'not a valid email')
+
+    def test_set_invalid_multi_value(self):
+        self.assertRaisesMessage(CommandError, "Enter a list of values.",
+                                 call_command, 'constance', 'set', 'DATETIME_VALUE', '2011-09-24 12:30:25')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,6 @@ from constance import config
 
 
 class CliTestCase(TransactionTestCase):
-
     def setUp(self):
         self.out = StringIO()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,10 @@ u"""        BOOL_VALUE	True
 
         self.assertEqual(config.EMAIL_VALUE, "blah@example.com")
 
+        call_command('constance', *('set', 'DATETIME_VALUE', '2011-09-24 12:30:25'), stdout=self.out)
+
+        self.assertEqual(config.DATETIME_VALUE, "2011-09-24 12:30:25")
+
     def test_get_invalid_name(self):
         self.assertRaisesMessage(CommandError, "NOT_A_REAL_CONFIG is not defined in settings.CONSTANCE_CONFIG",
                                  call_command, 'constance', 'get', 'NOT_A_REAL_CONFIG')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,8 @@ class UtilsTestCase(TestCase):
     def test_set_value_validation(self):
         self.assertRaisesMessage(ValidationError, 'Enter a whole number.', _set_constance_value, 'INT_VALUE', 'foo')
         self.assertRaisesMessage(ValidationError, 'Enter a valid email address.', _set_constance_value, 'EMAIL_VALUE', 'not a valid email')
+        self.assertRaisesMessage(ValidationError, 'Enter a valid date.', _set_constance_value, 'DATETIME_VALUE', ('2000-00-00', '99:99:99',))
+        self.assertRaisesMessage(ValidationError, 'Enter a valid time.', _set_constance_value, 'DATETIME_VALUE', ('2016-01-01', '99:99:99',))
 
     def test_get_values(self):
 


### PR DESCRIPTION
Require each value to be passed as a separate argument, so we can use the normal field logic to combine them, resolves #186 

see docs https://github.com/jazzband/django-constance/compare/cli_set_datetime?expand=1#diff-caf2a6b8f4947d018f68893c695b5202R276

Also added myself to AUTHORS