### PR TITLE
Fix Reset to default for DateTime, #185

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -180,6 +180,7 @@ class ConstanceAdmin(admin.ModelAdmin):
             'form_field': form[name],
             'is_checkbox': isinstance(
                 form[name].field.widget, forms.CheckboxInput),
+            'is_datetime': isinstance(default, datetime),
         }
 
         return config_value

--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -22,17 +22,23 @@
             <br>
             <a href="#" onClick="
               {% if item.is_datetime %}
-                d = new Date(
+                var defaultDate = new Date(
                   {{ item.raw_default|date:"Y" }},
                   {{ item.raw_default|date:"n" }} - 1,
                   {{ item.raw_default|date:"j" }},
                   {{ item.raw_default|time:"H" }},
                   {{ item.raw_default|time:"i" }},
                   {{ item.raw_default|time:"s" }});
+                var body = document.getElementsByTagName('body')[0];
+                var serverOffset = body.getAttribute('data-admin-utc-offset');
+                if (serverOffset) {
+                  var defaultOffset = defaultDate.getTimezoneOffset() * -60;
+                  defaultDate.setTime(defaultDate.getTime() + 1000 * (serverOffset - defaultOffset));
+                }                              
                 document.getElementById('{{ item.form_field.auto_id }}_0').value =
-                  d.strftime(get_format('DATE_INPUT_FORMATS')[0]);
+                  defaultDate.strftime(get_format('DATE_INPUT_FORMATS')[0]);
                 document.getElementById('{{ item.form_field.auto_id }}_1').value =
-                  d.strftime(get_format('TIME_INPUT_FORMATS')[0]);
+                  defaultDate.strftime(get_format('TIME_INPUT_FORMATS')[0]);
               {% else %}
                 document.getElementById('{{ item.form_field.auto_id }}').{% if item.is_checkbox %}checked =
                     {% if item.raw_default %} true {% else %} false {% endif %}

--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -21,9 +21,23 @@
             {{ item.form_field }}
             <br>
             <a href="#" onClick="
-              document.getElementById('{{ item.form_field.auto_id }}').{% if item.is_checkbox %}checked =
-                  {% if item.raw_default %} true {% else %} false {% endif %}
-                {% else %}value = '{{ item.default|escapejs }}'{% endif %}; return false;">Reset to default</a>
+              {% if item.is_datetime %}
+                d = new Date(
+                  {{ item.raw_default|date:"Y" }},
+                  {{ item.raw_default|date:"n" }} - 1,
+                  {{ item.raw_default|date:"j" }},
+                  {{ item.raw_default|time:"H" }},
+                  {{ item.raw_default|time:"i" }},
+                  {{ item.raw_default|time:"s" }});
+                document.getElementById('{{ item.form_field.auto_id }}_0').value =
+                  d.strftime(get_format('DATE_INPUT_FORMATS')[0]);
+                document.getElementById('{{ item.form_field.auto_id }}_1').value =
+                  d.strftime(get_format('TIME_INPUT_FORMATS')[0]);
+              {% else %}
+                document.getElementById('{{ item.form_field.auto_id }}').{% if item.is_checkbox %}checked =
+                    {% if item.raw_default %} true {% else %} false {% endif %}
+                  {% else %}value = '{{ item.default|escapejs }}'{% endif %}
+              {% endif %}; return false;">Reset to default</a>
         </td>
         <td>
             {% if item.modified %}


### PR DESCRIPTION
* I added a flag in the context for `DateTime` type
* In the template I use `get_format('DATE_INPUT_FORMATS')[0]` and `get_format('TIME_INPUT_FORMATS')[0]` from Django Admin to format the date and time. I similar pattern is used in for *Now* and *Today* functionality available in the widget.