### PR TITLE
Fixed Django 2.0 tests due to `django.conf.urls.include` behavior change. Removed pypy for Django 2.0 tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,12 @@ env:
   - TOXENV=pypy-django-19
   - TOXENV=pypy-django-110
   - TOXENV=pypy-django-111
-  - TOXENV=pypy-django-master
 matrix:
   allow_failures:
     - env: TOXENV=py27-django-111
     - env: TOXENV=py35-django-111
     - env: TOXENV=pypy-django-111
     - env: TOXENV=py35-django-master
-    - env: TOXENV=pypy-django-master
 script:
 - tox
 deploy:

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,5 +4,5 @@ from django.conf.urls import url, include
 
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py27,py35,pypy}-django-{18,19,110,111}
-    {py35,pypy}-django-master
+    {py35}-django-master
 
 [testenv]
 basepython =


### PR DESCRIPTION
Fixed Django 2.0 tests due to `django.conf.urls.include` behavior change i.e.
```
django.core.exceptions.ImproperlyConfigured: Passing a 3-tuple to django.conf.urls.include()
is not supported. Pass a 2-tuple containing the list of patterns and app_name, and provide
the namespace argument to include() instead.
```
Removed pypy for Django 2.0 tests. We cannot use `pypy3` instead (see https://github.com/travis-ci/travis-ci/issues/6277).