### PR TITLE
Added the old value to the config_updated signal

### DIFF
--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -77,6 +77,7 @@ class DatabaseBackend(Backend):
         return value
 
     def set(self, key, value):
+        old_value = self.get(key)
         constance, created = self._model._default_manager.get_or_create(
             key=self.add_prefix(key), defaults={'value': value}
         )
@@ -87,7 +88,7 @@ class DatabaseBackend(Backend):
             self._cache.set(key, value)
 
         signals.config_updated.send(
-            sender=config, updated_key=key, new_value=value
+            sender=config, key=key, old_value=old_value, new_value=value
         )
 
     def clear(self, sender, instance, created, **kwargs):

--- a/constance/backends/redisd.py
+++ b/constance/backends/redisd.py
@@ -48,7 +48,8 @@ class RedisBackend(Backend):
                 yield key, loads(value)
 
     def set(self, key, value):
+        old_value = self.get(key)
         self._rd.set(self.add_prefix(key), dumps(value))
         signals.config_updated.send(
-            sender=config, updated_key=key, new_value=value
+            sender=config, key=key, old_value=old_value, new_value=value
         )

--- a/constance/signals.py
+++ b/constance/signals.py
@@ -1,5 +1,5 @@
 import django.dispatch
 
 config_updated = django.dispatch.Signal(
-    providing_args=['updated_key', 'new_value']
+    providing_args=['key', 'old_value', 'new_value']
 )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,8 +81,8 @@ You can use it as:
     from constance.signals import config_updated
 
     @receiver(config_updated)
-    def constance_updated(sender, updated_key, new_value, **kwargs):
-        print(sender, updated_key, new_value)
+    def constance_updated(sender, key, old_value, new_value, **kwargs):
+        print(sender, key, old_value, new_value)
 
 The sender is the ``config`` object, and the ``updated_key`` and ``new_value``
 are the ones just changed.


### PR DESCRIPTION
One of the main uses of the config_updated signal is to act accordingly to field changes. Signal is already providing the key and the new value, but it misses the old value so anyone can compare if it was changed.

I'm proposing here to send into the signal the old value as well as the new value, so it allows to compare if the value was changed and act accordingly.

@jezdez Could you please take a look and let me know what you think?