### PR TITLE
Removed unnecessary `stdout` bytes encode.

### DIFF
--- a/constance/management/commands/constance.py
+++ b/constance/management/commands/constance.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
 
         if command == 'get':
             try:
-                self.stdout.write("{}".format(getattr(config, key)).encode('utf-8'), ending=b"\n")
+                self.stdout.write("{}".format(getattr(config, key)), ending="\n")
             except AttributeError as e:
                 raise CommandError(key + " is not defined in settings.CONSTANCE_CONFIG")
 
@@ -64,4 +64,4 @@ class Command(BaseCommand):
 
         elif command == 'list':
             for k, v in get_values().items():
-                self.stdout.write("{}\t{}".format(k, v).encode('utf-8'), ending=b"\n")
+                self.stdout.write("{}\t{}".format(k, v), ending="\n")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -64,7 +64,7 @@ CONSTANCE_CONFIG = {
     'LONG_VALUE': (long_value, 'some looong int'),
     'BOOL_VALUE': (True, 'true or false'),
     'STRING_VALUE': ('Hello world', 'greetings'),
-    'UNICODE_VALUE': (u'Rivière-Bonjour', 'greetings'),
+    'UNICODE_VALUE': (u'Rivière-Bonjour რუსთაველი', 'greetings'),
     'DECIMAL_VALUE': (Decimal('0.1'), 'the first release version'),
     'DATETIME_VALUE': (datetime(2010, 8, 23, 11, 29, 24),
                        'time of the first commit'),

--- a/tests/storage.py
+++ b/tests/storage.py
@@ -22,7 +22,7 @@ class StorageTestsMixin(object):
         self.assertEqual(self.config.LONG_VALUE, long(123456))
         self.assertEqual(self.config.BOOL_VALUE, True)
         self.assertEqual(self.config.STRING_VALUE, 'Hello world')
-        self.assertEqual(self.config.UNICODE_VALUE, u'Rivière-Bonjour')
+        self.assertEqual(self.config.UNICODE_VALUE, u'Rivière-Bonjour რუსთაველი')
         self.assertEqual(self.config.DECIMAL_VALUE, Decimal('0.1'))
         self.assertEqual(self.config.DATETIME_VALUE, datetime(2010, 8, 23, 11, 29, 24))
         self.assertEqual(self.config.FLOAT_VALUE, 3.1415926536)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ u"""        BOOL_VALUE	True
         TIME_VALUE	23:59:59
         LONG_VALUE	123456
         STRING_VALUE	Hello world
-        UNICODE_VALUE	Rivière-Bonjour
+        UNICODE_VALUE	Rivière-Bonjour რუსთაველი
         CHOICE_VALUE	yes
         DECIMAL_VALUE	0.1
         DATETIME_VALUE	2010-08-23 11:29:24

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,7 @@ class UtilsTestCase(TestCase):
             'LINEBREAK_VALUE': 'Spam spam',
             'DECIMAL_VALUE': Decimal('0.1'),
             'STRING_VALUE': 'Hello world',
-            'UNICODE_VALUE': u'Rivière-Bonjour',
+            'UNICODE_VALUE': u'Rivière-Bonjour რუსთაველი',
             'DATETIME_VALUE': datetime.datetime(2010, 8, 23, 11, 29, 24),
             'LONG_VALUE': 123456
         })


### PR DESCRIPTION
I removed unnecessary `stdout` bytes encode. This PR fixes Django 2.0 tests e.g.:
```
======================================================================
ERROR: test_list (tests.test_cli.CliTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django-constance/tests/test_cli.py", line 25, in test_list
    call_command('constance', 'list', stdout=self.out)
  File "/django-constance/.tox/py35-django-master/lib/python3.5/site-packages/django/core/management/__init__.py", line 128, in call_command
    return command.execute(*args, **defaults)
  File "/django-constance/.tox/py35-django-master/lib/python3.5/site-packages/django/core/management/base.py", line 327, in execute
    output = self.handle(*args, **options)
  File "/django-constance/constance/management/commands/constance.py", line 67, in handle
    self.stdout.write("{}\t{}".format(k, v).encode('utf-8'), ending=b"\n")
  File "/django-constance/.tox/py35-django-master/lib/python3.5/site-packages/django/core/management/base.py", line 107, in write
    self._out.write(style_func(msg))
TypeError: string argument expected, got 'bytes'
```