### PR TITLE
Fix create_perm in apps.py to use database alias given by the post_migrate signal

### DIFF
--- a/constance/apps.py
+++ b/constance/apps.py
@@ -12,7 +12,7 @@ class ConstanceConfig(AppConfig):
         signals.post_migrate.connect(self.create_perm,
                                      dispatch_uid='constance.create_perm')
 
-    def create_perm(self, *args, **kwargs):
+    def create_perm(self, using=None, *args, **kwargs):
         """
         Creates a fake content type and permission
         to be able to check for permissions
@@ -21,12 +21,12 @@ class ConstanceConfig(AppConfig):
         from django.contrib.contenttypes.models import ContentType
 
         if ContentType._meta.installed and Permission._meta.installed:
-            content_type, created = ContentType.objects.get_or_create(
+            content_type, created = ContentType.objects.using(using).get_or_create(
                 app_label='constance',
                 model='config',
             )
 
-            permission, created = Permission.objects.get_or_create(
+            permission, created = Permission.objects.using(using).get_or_create(
                 name='Can change config',
                 content_type=content_type,
                 codename='change_config')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -23,6 +23,10 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': ':memory:',
+    },
+    'secondary': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
     }
 }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,46 @@
+from django.apps import apps
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import signals
+from django.test import TestCase
+
+
+class TestApp(TestCase):
+    def setUp(self):
+        self.app_config = apps.get_app_config('constance')
+
+    def test_post_migrate_signal_creates_content_type_and_permission_in_default_database(self):
+        self.assert_uses_correct_database('default')
+
+    def test_post_migrate_signal_creates_content_type_and_permission_in_secondary_database(self):
+        self.assert_uses_correct_database('secondary')
+
+    def test_uses_default_db_even_without_giving_using_keyword(self):
+        self.call_post_migrate(None)
+
+        self.assert_content_type_and_permission_created('default')
+
+    def assert_uses_correct_database(self, database_name):
+        self.call_post_migrate(database_name)
+
+        self.assert_content_type_and_permission_created(database_name)
+
+    def assert_content_type_and_permission_created(self, database_name):
+        content_type_queryset = ContentType.objects.filter(app_label=self.app_config.name) \
+            .using(database_name)
+
+        self.assertTrue(content_type_queryset.exists())
+
+        permission_queryset = Permission.objects.filter(content_type=content_type_queryset.get()) \
+            .using(database_name).exists()
+
+        self.assertTrue(permission_queryset)
+
+    def call_post_migrate(self, database_name):
+        signals.post_migrate.send(
+            sender=self.app_config,
+            app_config=self.app_config,
+            verbosity=None,
+            interactive=None,
+            using=database_name
+        )


### PR DESCRIPTION
While running migrations with multiple databases I have noticed that the create_perm signal handler doesn't use the given "using" argument, which means that it always creates the ContentType and Permission in the default database.

The fix is to use the "using" argument on the objects manager with the using method. 

I have also added tests for this, which needed an extra "secondary" database in the settings.py.
This means that every db setup is done twice, which is unnecessary for every other tests, but I don't think that is possible to add a new database to the settings for only one test case.