### PR TITLE
Add a `get_changelist_form` hook in `ConstanceAdmin`

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -184,14 +184,23 @@ class ConstanceAdmin(admin.ModelAdmin):
 
         return config_value
 
+    def get_changelist_form(self, request):
+        """
+        Returns a Form class for use in the changelist_view.
+        """
+        # Defaults to self.change_list_form in order to preserve backward
+        # compatibility
+        return self.change_list_form
+
     @csrf_protect_m
     def changelist_view(self, request, extra_context=None):
         if not self.has_change_permission(request, None):
             raise PermissionDenied
         initial = get_values()
-        form = self.change_list_form(initial=initial)
+        form_cls = self.get_changelist_form(request)
+        form = form_cls(initial=initial)
         if request.method == 'POST':
-            form = self.change_list_form(data=request.POST, initial=initial)
+            form = form_cls(data=request.POST, initial=initial)
             if form.is_valid():
                 form.save()
                 messages.add_message(

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -332,6 +332,24 @@ settings the way you like.
     admin.site.unregister([Config])
     admin.site.register([Config], ConfigAdmin)
 
+You can also override the ``get_changelist_form`` method which is called in
+``get_changelist_view`` to get the actual form used to change the settings. This
+allows you to pick a different form according to the user that makes the
+request. For example:
+
+.. code-block:: python
+
+    class SuperuserForm(ConstanceForm):
+        # Do some stuff here
+
+    class MyConstanceAdmin(ConstanceAdmin):
+        def get_changelist_form(self, request):
+            if request.user.is_superuser:
+              return SuperuserForm:
+            else:
+              return super(MyConstanceAdmin, self).get_changelist_form(request)
+
+Note that the default method returns ``self.change_list_form``.
 
 More documentation
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -333,7 +333,7 @@ settings the way you like.
     admin.site.register([Config], ConfigAdmin)
 
 You can also override the ``get_changelist_form`` method which is called in
-``get_changelist_view`` to get the actual form used to change the settings. This
+``changelist_view`` to get the actual form used to change the settings. This
 allows you to pick a different form according to the user that makes the
 request. For example:
 


### PR DESCRIPTION
This method is used in the `changelist_view` to get the changelist form.
    
You may want to override this method to serve different forms depending
on the user that make the request. For example:
    
    class MyConstanceAdmin(ConstanceAdmin):
        def get_changelist_form(self, request):
            if request.user.is_superuser:
                return SuperuserForm:
            else:
                return super(MyConstanceAdmin, self).get_changelist_form(request)

Django's `ModelAdmin` has similar hooks which are pretty useful when you need to allow different groups of users with different privileges to access the admin site.