### PR TITLE
Add python 3.6 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
   - TOXENV=pypy-django-110
   - TOXENV=pypy-django-111
 matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36-django-111
   allow_failures:
     - env: TOXENV=py35-django-master
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist =
-    {py27,py35,pypy}-django-{18,19,110,111}
+    {py27,py35,py36,pypy}-django-{18,19,110,111}
     {py35}-django-master
 
 [testenv]
 basepython =
     py27: python2.7
     py35: python3.5
+    py36: python3.6
     pypy: pypy
 deps =
     redis


### PR DESCRIPTION
I only have 2.7 and 3.6 on my machine, was helpful to get this in the tox.ini file. 
We need to set the python version explicitly on Travis, though, otherwise, it raises an interpreter not found error.