### PR TITLE
fix bug when site has multiple databases. 

### DIFF
--- a/constance/apps.py
+++ b/constance/apps.py
@@ -12,7 +12,7 @@ class ConstanceConfig(AppConfig):
         signals.post_migrate.connect(self.create_perm,
                                      dispatch_uid='constance.create_perm')
 
-    def create_perm(self, using=None, *args, **kwargs):
+    def create_perm(self, *args, **kwargs):
         """
         Creates a fake content type and permission
         to be able to check for permissions
@@ -21,12 +21,12 @@ class ConstanceConfig(AppConfig):
         from django.contrib.contenttypes.models import ContentType
 
         if ContentType._meta.installed and Permission._meta.installed:
-            content_type, created = ContentType.objects.using(using).get_or_create(
+            content_type, created = ContentType.objects.get_or_create(
                 app_label='constance',
                 model='config',
             )
 
-            permission, created = Permission.objects.using(using).get_or_create(
+            permission, created = Permission.objects.get_or_create(
                 name='Can change config',
                 content_type=content_type,
                 codename='change_config')


### PR DESCRIPTION
ContentType now relys on the site's DB router instead of explicity setting a database via using(). 