### PR TITLE
Remove unnecessary calls to dict.keys

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -93,8 +93,7 @@ def get_values():
     default_initial = ((name, options[0])
                        for name, options in settings.CONFIG.items())
     # Then update the mapping with actually values from the backend
-    initial = dict(default_initial,
-                   **dict(config._backend.mget(settings.CONFIG.keys())))
+    initial = dict(default_initial, **dict(config._backend.mget(settings.CONFIG)))
 
     return initial
 
@@ -230,9 +229,7 @@ class ConstanceAdmin(admin.ModelAdmin):
         if settings.CONFIG_FIELDSETS:
             context['fieldsets'] = []
             for fieldset_title, fields_list in settings.CONFIG_FIELDSETS.items():
-                fields_exist = all(
-                    field in settings.CONFIG.keys() for field in fields_list
-                )
+                fields_exist = all(field in settings.CONFIG for field in fields_list)
                 assert fields_exist, "CONSTANCE_CONFIG_FIELDSETS contains fields that does not exist"
                 config_values = []
 

--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -45,7 +45,7 @@ class DatabaseBackend(Backend):
             return
         autofill_values = {}
         autofill_values[full_cachekey] = 1
-        for key, value in self.mget(settings.CONFIG.keys()):
+        for key, value in self.mget(settings.CONFIG):
             autofill_values[self.add_prefix(key)] = value
         self._cache.set_many(autofill_values, timeout=self._autofill_timeout)
 
@@ -53,7 +53,7 @@ class DatabaseBackend(Backend):
         if not keys:
             return
         keys = dict((self.add_prefix(key), key) for key in keys)
-        stored = self._model._default_manager.filter(key__in=keys.keys())
+        stored = self._model._default_manager.filter(key__in=keys)
         for const in stored:
             yield keys[const.key], const.value
 
@@ -93,7 +93,7 @@ class DatabaseBackend(Backend):
 
     def clear(self, sender, instance, created, **kwargs):
         if self._cache and not created:
-            keys = [self.add_prefix(k) for k in settings.CONFIG.keys()]
+            keys = [self.add_prefix(k) for k in settings.CONFIG]
             keys.append(self.add_prefix(self._autofill_cachekey))
             self._cache.delete_many(keys)
             self.autofill()

--- a/constance/test/utils.py
+++ b/constance/test/utils.py
@@ -64,7 +64,7 @@ class override_config(override_settings):
         Store original config values and set overridden values.
         """
         # Store the original values to an instance variable
-        for config_key in self.options.keys():
+        for config_key in self.options:
             self.original_values[config_key] = getattr(config, config_key)
 
         # Update config with the overriden values


### PR DESCRIPTION
iter(dict) is equivalent to iter(dict.keys()). Can simply act on the
dict instead. Provides a more concise, Pythonic syntax and avoids an
unnecessary function call.

Inspired by Lennart Regebro's presentation "Prehistoric Patterns in
Python" at PyCon 2017. Available at:

https://www.youtube.com/watch?v=V5-JH23Vk0I