### PR TITLE
add config label

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -292,6 +292,7 @@ class ConstanceAdmin(admin.ModelAdmin):
 
 class Config(object):
     class Meta(object):
+        label = 'constance.Config'
         app_label = 'constance'
         object_name = 'Config'
         model_name = module_name = 'config'


### PR DESCRIPTION
This modification is not only for a prevention of below error but also providing `model.label`.
I think this is not a mandatory or core PR but I think the model should have the label for later usage or compatible with others.

```python
File "/Users/legshort/.pyenv/versions/project/lib/python3.6/site-packages/admin_view_permission/utils.py", line 26, in get_model_name
    return model._meta.label
AttributeError: 'Meta' object has no attribute 'label'
```