### PR TITLE
Workaround to make `django-constance` work in multi-DB project

### DIFF
--- a/constance/apps.py
+++ b/constance/apps.py
@@ -16,9 +16,13 @@ class ConstanceConfig(AppConfig):
         Creates a fake content type and permission
         to be able to check for permissions
         """
+        from django.conf import settings
         from django.contrib.auth.models import Permission
         from django.contrib.contenttypes.models import ContentType
 
+        constance_dbs = getattr(settings, 'CONSTANCE_DBS', None)
+        if constance_dbs is not None and using not in constance_dbs:
+            return
         if ContentType._meta.installed and Permission._meta.installed:
             content_type, created = ContentType.objects.using(using).get_or_create(
                 app_label='constance',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import signals
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 class TestApp(TestCase):
@@ -19,6 +19,14 @@ class TestApp(TestCase):
         self.call_post_migrate(None)
 
         self.assert_content_type_and_permission_created('default')
+
+    @override_settings(CONSTANCE_DBS=['default'])
+    def test_only_use_databases_in_constance_dbs(self):
+        Permission.objects.using('default').delete()
+        Permission.objects.using('secondary').delete()
+        self.assert_uses_correct_database('default')
+        with self.assertRaises(AssertionError):
+            self.assert_uses_correct_database('secondary')
 
     def assert_uses_correct_database(self, database_name):
         self.call_post_migrate(database_name)


### PR DESCRIPTION
This is an attempt to fix the issue described in #210. What this PR does is add a `CONSTANCE_DBS` setting to the Django settings file. This is an interable that says which databases should be affected by the `django-constance` post-migration signals.

Not sure if this is the best way to fix this, but it seems to work for me ¯\\\_(ツ)_/¯

Totally open to better name suggestions than `CONSTANCE_DBS` :+1: 