### PR TITLE
fix(admin): date type

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -206,6 +206,7 @@ class ConstanceAdmin(admin.ModelAdmin):
             'value': localize(value),
             'modified': localize(value) != localize(default),
             'form_field': form[name],
+            'is_date': isinstance(default, date),
             'is_datetime': isinstance(default, datetime),
             'is_checkbox': isinstance(form[name].field.widget, forms.CheckboxInput),
             'is_file': isinstance(form[name].field.widget, forms.FileInput),

--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -31,6 +31,7 @@
                 data-default="{% spaceless %}
                 {% if item.is_checkbox %}{% if item.raw_default %} true {% else %} false {% endif %}
                 {% elif item.is_datetime %}{{ item.raw_default|date:"U" }}
+                {% elif item.is_date %}{{ item.raw_default.isoformat }}
                 {% else %}{{ item.default }}
                 {% endif %}
                 {% endspaceless %}">{% trans "Reset to default" %}</a>


### PR DESCRIPTION
When date type in constance it is shown as "April 1, 2018" as default for example and after push on "Reset to default" input field looks like "April 1, 2018" instead of "2018-04-01" and of course it tells that it is not valid.