### PR TITLE
fix bug of can't change permission chang_config's name

### DIFF
--- a/constance/apps.py
+++ b/constance/apps.py
@@ -30,6 +30,6 @@ class ConstanceConfig(AppConfig):
             )
 
             permission, created = Permission.objects.using(using).get_or_create(
-                name='Can change config',
                 content_type=content_type,
-                codename='change_config')
+                codename='change_config',
+                defaults={'name': 'Can change config'})


### PR DESCRIPTION
If i change the permission `change_config`'s name to other name and `migrate` i will get this error:
```
django.db.utils.IntegrityError: (1062, "Duplicate entry '2-change_config' for key 'auth_permission_content_type_id_codename_01a
b375a_uniq'")
```