### PR TITLE
Improve consistency of reset value handling for `date`

### DIFF
--- a/constance/static/admin/js/constance.js
+++ b/constance/static/admin/js/constance.js
@@ -11,6 +11,9 @@
 
             if (fieldType === 'checkbox') {
                 field.prop('checked', this.dataset.default === 'true');
+            } else if (fieldType === 'date') {
+                var defaultDate = new Date(this.dataset.default * 1000);
+                $('#' + this.dataset.fieldId).val(defaultDate.strftime(get_format('DATE_INPUT_FORMATS')[0]));}
             } else if (fieldType === 'datetime') {
                 var defaultDate = new Date(this.dataset.default * 1000);
                 $('#' + this.dataset.fieldId + '_0').val(defaultDate.strftime(get_format('DATE_INPUT_FORMATS')[0]));

--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -25,13 +25,14 @@
                 data-field-id="{{ item.form_field.auto_id }}"
                 data-field-type="{% spaceless %}
                 {% if item.is_checkbox %}checkbox
+                {% elif item.is_date %}date
                 {% elif item.is_datetime %}datetime
                 {% endif %}
                 {% endspaceless %}"
                 data-default="{% spaceless %}
                 {% if item.is_checkbox %}{% if item.raw_default %} true {% else %} false {% endif %}
+                {% elif item.is_date %}{{ item.raw_default|date:"U" }}
                 {% elif item.is_datetime %}{{ item.raw_default|date:"U" }}
-                {% elif item.is_date %}{{ item.raw_default.isoformat }}
                 {% else %}{{ item.default }}
                 {% endif %}
                 {% endspaceless %}">{% trans "Reset to default" %}</a>


### PR DESCRIPTION
#### Summary

* Follow-on for #274 by @DmitryKaramin
* Consistent implementation re: `datetime`
* Consistent reset using `DATE_INPUT_FORMAT`, i.e.
  - Works whether `USE_L10N` setting is active or not

---

#### Explanation

I've been using v2.2.0 and had issues with handling dates.  Stated making my own modifications but then came across #274, which resolves the problem.

This PR makes the solution more consistent, both with the surrounding code as well as the actual reset value format, i.e. brings it into line with `datetime`.