### PR TITLE
WIP: in django>=2.1 cmd was removed as parameter to add_parser

### DIFF
--- a/constance/management/commands/constance.py
+++ b/constance/management/commands/constance.py
@@ -32,12 +32,12 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         subparsers = parser.add_subparsers(dest='command')
 
-        parser_list = subparsers.add_parser('list', cmd=self, help='list all Constance keys and their values')
+        parser_list = subparsers.add_parser('list', help='list all Constance keys and their values')
 
-        parser_get = subparsers.add_parser('get', cmd=self, help='get the value of a Constance key')
+        parser_get = subparsers.add_parser('get', help='get the value of a Constance key')
         parser_get.add_argument('key', help='name of the key to get', metavar='KEY')
 
-        parser_set = subparsers.add_parser('set', cmd=self, help='set the value of a Constance key')
+        parser_set = subparsers.add_parser('set', help='set the value of a Constance key')
         parser_set.add_argument('key', help='name of the key to get', metavar='KEY')
         # use nargs='+' so that we pass a list to MultiValueField (eg SplitDateTimeField)
         parser_set.add_argument('value', help='value to set', metavar='VALUE', nargs='+')


### PR DESCRIPTION
I have not tested it with django<2.1 so I can not tell which side-effects this may have. From the code only the error method seems to be potentially effected.

Ideally django should have popped "cmd" from the kwargs when changing the API in 2.1. For an analysis please see #294.

If this has side-effects another option would be to call two apis based on django version,e.g

```
if djang0.VERSION >= (2,1):
  # do one thing
else:
  # do another thing
```