### PR TITLE
show not existing fields in field_list

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -259,8 +259,12 @@ class ConstanceAdmin(admin.ModelAdmin):
         if settings.CONFIG_FIELDSETS:
             context['fieldsets'] = []
             for fieldset_title, fields_list in settings.CONFIG_FIELDSETS.items():
-                fields_exist = all(field in settings.CONFIG for field in fields_list)
-                assert fields_exist, "CONSTANCE_CONFIG_FIELDSETS contains field(s) that does not exist"
+                absent_fields = [field for field in fields_list
+                                 if field not in settings.CONFIG]
+                assert not any(absent_fields), (
+                    "CONSTANCE_CONFIG_FIELDSETS contains field(s) that does "
+                    "not exist: %s" % ', '.join(absent_fields))
+
                 config_values = []
 
                 for name in fields_list:


### PR DESCRIPTION
When missing a field mentioned in `CONSTANCE_CONFIG_FIELDSETS` in `CONSTANCE_CONFIG`, the error message is no explicit about the variable.

`AssertionError: CONSTANCE_CONFIG_FIELDSETS contains field(s) that does not exist `

 To make the debugging easier, I include the missing variables in the error message

AssertionError: CONSTANCE_CONFIG_FIELDSETS contains field(s) that does not exist: example_field_1
