### PR TITLE
Use default_storage to save file

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -13,6 +13,7 @@ from django.contrib import admin, messages
 from django.contrib.admin import widgets
 from django.contrib.admin.options import csrf_protect_m
 from django.core.exceptions import PermissionDenied, ImproperlyConfigured
+from django.core.files.storage import default_storage
 from django.forms import fields
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
@@ -137,11 +138,8 @@ class ConstanceForm(forms.Form):
     def save(self):
         for file_field in self.files:
             file = self.cleaned_data[file_field]
-            file_path = os.path.join(django_settings.MEDIA_ROOT, file.name)
-            with open(file_path, 'wb+') as destination:
-                for chunk in file.chunks():
-                    destination.write(chunk)
-                self.cleaned_data[file_field] = file.name
+            default_storage.save(file.name, file)
+            self.cleaned_data[file_field] = file.name
 
         for name in settings.CONFIG:
             if getattr(config, name) != self.cleaned_data[name]:


### PR DESCRIPTION
The current behavior of saving files is to save locally using `open` and `MEDIA_ROOT` which doesn't work when your storage is a remote one (eg. S3). Using `default_storage` will use whatever you had configured in your settings.