### PR TITLE
ConstanceForm save method tweak to store the actual filename

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -139,8 +139,7 @@ class ConstanceForm(forms.Form):
     def save(self):
         for file_field in self.files:
             file = self.cleaned_data[file_field]
-            default_storage.save(file.name, file)
-            self.cleaned_data[file_field] = file.name
+            self.cleaned_data[file_field] = default_storage.save(file.name, file)
 
         for name in settings.CONFIG:
             if getattr(config, name) != self.cleaned_data[name]:


### PR DESCRIPTION
We need to store the actual name of the file, which the storage's save method provides. Otherwise, if we upload a new file with the same name as the already stored file has, the Constance config will keep a link to the old file.