### PR TITLE
use return value of default_storage.save() as path

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -139,8 +139,7 @@ class ConstanceForm(forms.Form):
     def save(self):
         for file_field in self.files:
             file = self.cleaned_data[file_field]
-            default_storage.save(file.name, file)
-            self.cleaned_data[file_field] = file.name
+            self.cleaned_data[file_field] = default_storage.save(file.name, file)
 
         for name in settings.CONFIG:
             if getattr(config, name) != self.cleaned_data[name]:


### PR DESCRIPTION
`default_storage.save()` returns the final path where the file was saved too. It may be different from the requested path.

According to Django's documentation on [`default_storage.save()`](https://docs.djangoproject.com/en/2.2/ref/files/storage/#django.core.files.storage.Storage.save) **...If there already exists a file with this name name, the storage system may modify the filename as necessary to get a unique name...**

Therefore It is necessary to use the returned path as the value for the Constance config.