### PR TITLE
Fixed "can't compare offset-naive and offset-aware datetimes"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test.db
 .tox
 .coverage
 docs/_build
+.idea

--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ saw2th <stephen@saw2th.co.uk>
 trbs <trbs@trbs.net>
 vl <1844144@gmail.com>
 vl <vl@u64.(none)>
+Dmitriy Tatarkin <mail@dtatarkin.ru>

--- a/constance/admin.py
+++ b/constance/admin.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from operator import itemgetter
 import hashlib
 
-from django import forms, VERSION
+from django import forms, VERSION, conf
 from django.apps import apps
 from django.conf.urls import url
 from django.contrib import admin, messages
@@ -143,7 +143,7 @@ class ConstanceForm(forms.Form):
             current = getattr(config, name)
             new = self.cleaned_data[name]
 
-            if isinstance(current, datetime) and not timezone.is_aware(current):
+            if conf.settings.USE_TZ and isinstance(current, datetime) and not timezone.is_aware(current):
                 current = timezone.make_aware(current)
 
             if current != new:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -63,6 +63,8 @@ CONSTANCE_ADDITIONAL_FIELDS = {
     'email': ('django.forms.fields.EmailField',),
 }
 
+USE_TZ = True
+
 CONSTANCE_CONFIG = {
     'INT_VALUE': (1, 'some int'),
     'LONG_VALUE': (long_value, 'some looong int'),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 
 from django.core.management import call_command, CommandError
 from django.test import TransactionTestCase
+from django.utils import timezone
 from django.utils.encoding import smart_str
 from django.utils.six import StringIO
 
@@ -53,7 +54,7 @@ u"""        BOOL_VALUE	True
 
         call_command('constance', *('set', 'DATETIME_VALUE', '2011-09-24', '12:30:25'), stdout=self.out)
 
-        self.assertEqual(config.DATETIME_VALUE, datetime(2011, 9, 24, 12, 30, 25))
+        self.assertEqual(config.DATETIME_VALUE, timezone.make_aware(datetime(2011, 9, 24, 12, 30, 25)))
 
     def test_get_invalid_name(self):
         self.assertRaisesMessage(CommandError, "NOT_A_REAL_CONFIG is not defined in settings.CONSTANCE_CONFIG",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from textwrap import dedent
 
+from django.conf import settings
 from django.core.management import call_command, CommandError
 from django.test import TransactionTestCase
 from django.utils import timezone
@@ -54,7 +55,10 @@ u"""        BOOL_VALUE	True
 
         call_command('constance', *('set', 'DATETIME_VALUE', '2011-09-24', '12:30:25'), stdout=self.out)
 
-        self.assertEqual(config.DATETIME_VALUE, timezone.make_aware(datetime(2011, 9, 24, 12, 30, 25)))
+        expected = datetime(2011, 9, 24, 12, 30, 25)
+        if settings.USE_TZ:
+            expected = timezone.make_aware(expected)
+        self.assertEqual(config.DATETIME_VALUE, expected)
 
     def test_get_invalid_name(self):
         self.assertRaisesMessage(CommandError, "NOT_A_REAL_CONFIG is not defined in settings.CONSTANCE_CONFIG",


### PR DESCRIPTION
The Issue https://github.com/jazzband/django-constance/issues/49 is reproduced when Django setting `USE_TZ = True`

