### PR TITLE
Simplify documentation installation section.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,23 +9,13 @@ Features
 
 .. image:: screenshot2.png
 
-Installation
-------------
-
-Install from PyPI the backend specific variant of django-constance:
-
-For the (default) Redis backend::
+Quick Installation
+------------------
 
     pip install "django-constance[redis]"
 
-For the database backend::
-
-    pip install "django-constance[database]"
-
-Alternatively -- if you're sure that the dependencies are already
-installed -- you can also run::
-
-    pip install django-constance
+For complete installation instructions, including how to install the
+database backend, see :ref:`Backends <backends>`.
 
 Configuration
 -------------


### PR DESCRIPTION
Make "Installation" section of documentation less fraught by only including instructions to install django-constance with the default Redis backend. This will reduce the chances of new users failing to
successfully install the database backend because it needs additional configuration.

Fixes #375.