### PR TITLE
Read-only form with correct perm

### DIFF
--- a/constance/apps.py
+++ b/constance/apps.py
@@ -29,7 +29,13 @@ class ConstanceConfig(AppConfig):
                 model='config',
             )
 
-            permission, created = Permission.objects.using(using).get_or_create(
+            Permission.objects.using(using).get_or_create(
                 content_type=content_type,
                 codename='change_config',
-                defaults={'name': 'Can change config'})
+                defaults={'name': 'Can change config'},
+            )
+            Permission.objects.using(using).get_or_create(
+                content_type=content_type,
+                codename='view_config',
+                defaults={'name': 'Can view config'},
+            )


### PR DESCRIPTION
Ref #254 

When `CONSTANCE_SUPERUSER_ONLY` is set to False, there is no way of displaying the values without the change permission.

This PR fixes this issue with the new `view_config` permission.