### PR TITLE
Switch md5 to sha256.

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -99,7 +99,7 @@ class ConstanceForm(forms.Form):
 
     def __init__(self, initial, request=None, *args, **kwargs):
         super().__init__(*args, initial=initial, **kwargs)
-        version_hash = hashlib.md5()
+        version_hash = hashlib.sha256()
 
         only_view = request and not request.user.has_perm('constance.change_config')
         if only_view:


### PR DESCRIPTION
When using a FIPS enabled machine, this line causes the following error because md5 is not allowed.

```
Traceback (most recent call last):
  File "/usr/local/lib64/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib64/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib64/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib64/python3.6/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib64/python3.6/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib64/python3.6/site-packages/django/contrib/admin/sites.py", line 223, in inner
    return view(request, *args, **kwargs)
  File "/usr/local/lib64/python3.6/site-packages/django/utils/decorators.py", line 45, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib64/python3.6/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/constance/admin.py", line 229, in changelist_view
    form = form_cls(initial=initial)
  File "/usr/local/lib/python3.6/site-packages/constance/admin.py", line 109, in __init__
    version_hash = hashlib.md5()
```

Since this is just a hash to see if there has been a change in the value, the change doesn't break anything, just allows it to run on FIPS systems. 

An alternative would be to allow this algorithm to be configurable, but don't think it is really something that needs to be configurable. SHA256 is reasonable, and available everywhere.