### PR TITLE
url() is deprecated in Django 3.1

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -6,7 +6,6 @@ import hashlib
 
 from django import forms, VERSION, conf
 from django.apps import apps
-from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin import widgets
 from django.contrib.admin.options import csrf_protect_m
@@ -21,6 +20,7 @@ from django.utils.formats import localize
 from django.utils.module_loading import import_string
 from django.utils.text import normalize_newlines
 from django.utils.translation import ugettext_lazy as _
+from django.urls import re_path
 
 from . import LazyConfig, settings
 from .checks import get_inconsistent_fieldnames
@@ -188,10 +188,10 @@ class ConstanceAdmin(admin.ModelAdmin):
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.module_name
         return [
-            url(r'^$',
+            re_path(r'^$',
                 self.admin_site.admin_view(self.changelist_view),
                 name='%s_%s_changelist' % info),
-            url(r'^$',
+            re_path(r'^$',
                 self.admin_site.admin_view(self.changelist_view),
                 name='%s_%s_add' % info),
         ]

--- a/constance/admin.py
+++ b/constance/admin.py
@@ -188,7 +188,7 @@ class ConstanceAdmin(admin.ModelAdmin):
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.module_name
         return [
-            re_path(r'^$',
+            path('',
                 self.admin_site.admin_view(self.changelist_view),
                 name='%s_%s_changelist' % info),
             re_path(r'^$',

--- a/constance/admin.py
+++ b/constance/admin.py
@@ -20,7 +20,7 @@ from django.utils.formats import localize
 from django.utils.module_loading import import_string
 from django.utils.text import normalize_newlines
 from django.utils.translation import ugettext_lazy as _
-from django.urls import re_path
+from django.urls import path
 
 from . import LazyConfig, settings
 from .checks import get_inconsistent_fieldnames

--- a/constance/admin.py
+++ b/constance/admin.py
@@ -191,7 +191,7 @@ class ConstanceAdmin(admin.ModelAdmin):
             path('',
                 self.admin_site.admin_view(self.changelist_view),
                 name='%s_%s_changelist' % info),
-            re_path(r'^$',
+            path('',
                 self.admin_site.admin_view(self.changelist_view),
                 name='%s_%s_add' % info),
         ]

--- a/example/cheeseshop/urls.py
+++ b/example/cheeseshop/urls.py
@@ -2,10 +2,13 @@ from django.conf.urls import url
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
 from django.conf import settings
+from django.urls import path
+
+
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]
 
 if settings.DEBUG:

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
 
-from django.conf.urls import url
+from django.urls import path
 
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
replaced url() functions with newer re_path() function and add path() functions to urls.py files