### PR TITLE
fixed field_list bug in checks.py

### DIFF
--- a/constance/checks.py
+++ b/constance/checks.py
@@ -38,7 +38,7 @@ def get_inconsistent_fieldnames():
 
     field_name_list = []
     for fieldset_title, fields_list in settings.CONFIG_FIELDSETS.items():
-        for field_name in fields_list:
+        for field_name in fields_list['fields']:
             field_name_list.append(field_name)
     if not field_name_list:
         return {}

--- a/constance/checks.py
+++ b/constance/checks.py
@@ -38,7 +38,9 @@ def get_inconsistent_fieldnames():
 
     field_name_list = []
     for fieldset_title, fields_list in settings.CONFIG_FIELDSETS.items():
-        for field_name in fields_list['fields']:
+        fields_list_indices = dict([i[::-1] for i in fields_list])
+        fields_indices_index = fields_list_indices['fields']
+        for field_name in fields_list[fields_indices_index]:
             field_name_list.append(field_name)
     if not field_name_list:
         return {}


### PR DESCRIPTION
fixed field_list bug, that get CONSTANCE_CONFIG_FIELDSETS tuple instead of get CONSTANCE_CONFIG_FIELDSETS fields dicts