### PR TITLE
Fix for the get_inconsistent_fieldnames() function. The fieldset can be a dictionary, not a tuple.

### DIFF
--- a/constance/checks.py
+++ b/constance/checks.py
@@ -2,7 +2,6 @@ from django.core import checks
 from django.utils.translation import ugettext_lazy as _
 
 
-
 @checks.register("constance")
 def check_fieldsets(*args, **kwargs):
     """
@@ -38,8 +37,11 @@ def get_inconsistent_fieldnames():
 
     field_name_list = []
     for fieldset_title, fields_list in settings.CONFIG_FIELDSETS.items():
-        for field_name in fields_list:
-            field_name_list.append(field_name)
+        # fields_list can be a dictionary, when a fieldset is defined as collapsible
+        # https://django-constance.readthedocs.io/en/latest/#fieldsets-collapsing
+        if isinstance(fields_list, dict) and 'fields' in fields_list:
+            fields_list = fields_list['fields']
+        field_name_list += list(fields_list)
     if not field_name_list:
         return {}
     return set(set(settings.CONFIG.keys()) - set(field_name_list))


### PR DESCRIPTION
The fix given the possibility that the fieldset could be a dictionary (when it defined as collapsible).
https://django-constance.readthedocs.io/en/latest/#fieldsets-collapsing
```
CONSTANCE_CONFIG = {
    'SITE_NAME': ('My Title', 'Website title'),
    'SITE_DESCRIPTION': ('', 'Website description'),
    'THEME': ('light-blue', 'Website theme'),
}

CONSTANCE_CONFIG_FIELDSETS = {
    'General Options': {
        'fields': ('SITE_NAME', 'SITE_DESCRIPTION'),
        'collapse': True
    },
    'Theme Options': ('THEME',),
}
```

Currently, if the set is defined as collapsible, there is no way to save changes due to incorrect validation.