### PR TITLE
Migrate to GitHub Actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    if: github.repository == 'jazzband/django-constance'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: release-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/tox.ini') }}
+          restore-keys: |
+            release-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U setuptools twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python setup.py sdist --format=gztar bdist_wheel
+          twine check dist/*
+
+      - name: Upload packages to Jazzband
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: jazzband
+          password: ${{ secrets.JAZZBAND_RELEASE_KEY }}
+          repository_url: https://jazzband.co/projects/django-constance/upload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key:
+          ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ matrix.python-version }}-v1-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+
+    - name: Tox tests
+      run: |
+        tox -v
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        name: Python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38,39,pypy3}-django{22}-unittest
-    py{36,37,38,39,pypy3}-django{30,31,-master}-unittest
-    py{36,37,38,39,pypy3}-django{22,30,31,-master}-pytest
+    py{36,37,38,39,py3}-django{22}-unittest
+    py{36,37,38,39,py3}-django{30,31,-master}-unittest
+    py{36,37,38,39,py3}-django{22,30,31,-master}-pytest
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,8 @@ ignore_outcome =
 commands =
     unittest: coverage run {envbindir}/django-admin test -v2
     unittest: coverage report
-    pytest: pytest --cov=. --ignore=.tox --disable-pytest-warnings {toxinidir}
+    unittest: coverage xml
+    pytest: pytest --cov=. --ignore=.tox --disable-pytest-warnings --cov-report=xml --cov-append {toxinidir}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     DJANGO_SETTINGS_MODULE=tests.settings

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,11 @@ commands =
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     DJANGO_SETTINGS_MODULE=tests.settings
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    pypy3: pypy3


### PR DESCRIPTION
Travis CI has a new pricing model which places limits on open source.

* https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
* https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

Many projects are moving to GitHub Actions instead, including Jazzband projects: 

* https://github.com/orgs/jazzband/projects/1
* https://github.com/jazzband-roadies/help/issues/206

This is based on https://github.com/jazzband/contextlib2/pull/26.

TODO:

* [x] @jezdez to add `JAZZBAND_RELEASE_KEY` to the repo secrets.