### PR TITLE
Don't call backend.set when backend.get returns None and default value is None

### DIFF
--- a/constance/base.py
+++ b/constance/base.py
@@ -17,7 +17,7 @@ class Config:
         except KeyError:
             raise AttributeError(key)
         result = self._backend.get(key)
-        if result is None:
+        if result is None and default is not None:
             result = default
             setattr(self, key, default)
             return result


### PR DESCRIPTION
Hi there!

**Preconditions:** 
Any constance variable 
default value: None
current value: None

Reading value through config.VALUE_NAME leads to backend.set('VALUE_NAME', None) call, which updates None to None.

This behaviour led us to database failure on production when 80 simultaneous value reads happen, which eventually led to  simultaneous writes and deadlocks. Deadlocks led to service restarts, emitting new connections to database and new deadlocks. 