### PR TITLE
Add default_auto_field to database backend

### DIFF
--- a/constance/backends/database/apps.py
+++ b/constance/backends/database/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ConstanceConfig(AppConfig):
+    name = 'constance.backends.database'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
This ensures that changing DEFAULT_AUTO_FIELD in settings.py doesn't
create migrations for constance.