### PR TITLE
Improve formatting of the pip install command

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,8 @@ Features
 Quick Installation
 ------------------
 
+.. code-block::
+
     pip install "django-constance[redis]"
 
 For complete installation instructions, including how to install the


### PR DESCRIPTION
Monospace the `pip install` command in the docs to make it easier to read.