### PR TITLE
Fix "Reset to default" for datetime fields

### DIFF
--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -31,8 +31,8 @@
                         data-field-id="{{ item.form_field.auto_id }}"
                         data-field-type="{% spaceless %}
                         {% if item.is_checkbox %}checkbox
-                        {% elif item.is_date %}date
                         {% elif item.is_datetime %}datetime
+                        {% elif item.is_date %}date
                         {% endif %}
                         {% endspaceless %}"
                         data-default="{% spaceless %}


### PR DESCRIPTION
When using a `datetime` field in `CONSTANCE_CONFIG`, it won't be recognized as `datetime` in the template, but as `date`, since `datetime` is a subclass of `date`.

This breaks the "Reset to default" button for `datetime` fields on the admin page.