### PR TITLE
Add documentation for constance_dbs config

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -110,6 +110,11 @@ Please make sure to apply the database migrations::
 
               python manage.py migrate database --fake
 
+.. note:: If you have multiple databases you can set what databases
+          will be used with ``CONSTANCE_DBS``
+
+              CONSTANCE_DBS = "default"
+
 Just like the Redis backend you can set an optional prefix that is used during
 database interactions (it defaults to an empty string, ``''``). To use
 something else do this::
@@ -137,17 +142,17 @@ configured cache backend to enable this feature, e.g. "default"::
              incompatible with cross-process caching like the local memory
              cache backend included in Django because correct cache
              invalidation can't be guaranteed.
-             
+
              If you try this, Constance will throw an error and refuse
              to let your application start. You can work around this by
              subclassing ``constance.backends.database.DatabaseBackend``
              and and overriding `__init__` to remove the check. You'll
              want to consult the source code for that function to see
-             exactly how. 
-             
-             We're deliberately being vague about this, because it's 
+             exactly how.
+
+             We're deliberately being vague about this, because it's
              dangerous; the behavior is undefined, and could even cause
-             your app to crash. Nevertheless, there are some limited 
+             your app to crash. Nevertheless, there are some limited
              circumstances in which this could be useful, but please
              think carefully before going down this path.
 


### PR DESCRIPTION
Documentation was missing for constance_dbs config.

If you have multiple databases and one of the DBs you have does not apply migrations for `contenttypes` then it is failing during migrating constance. Can be fixed with settings this option. It can be only found in changelog but there was no documentation.

Check #376 for example to the problem that I mentioned.