### PR TITLE
Add caching redis backend

### DIFF
--- a/constance/backends/redisd.py
+++ b/constance/backends/redisd.py
@@ -1,5 +1,5 @@
 from pickle import loads, dumps
-from threading import Lock
+from threading import RLock
 from time import monotonic
 
 from django.core.exceptions import ImproperlyConfigured
@@ -54,7 +54,7 @@ class RedisBackend(Backend):
 
 class CachingRedisBackend(RedisBackend):
     _sentinel = object()
-    _lock = Lock()
+    _lock = RLock()
 
     def __init__(self):
         super().__init__()
@@ -84,11 +84,10 @@ class CachingRedisBackend(RedisBackend):
             super().set(key, value)
             self._cache_value(key, value)
 
-
     def mget(self, keys):
         if not keys:
             return
         for key in keys:
             value = self.get(key)
-            if value:
+            if value is not None:
                 yield key, value

--- a/constance/backends/redisd.py
+++ b/constance/backends/redisd.py
@@ -81,10 +81,14 @@ class CachingRedisBackend(RedisBackend):
 
     def set(self, key, value):
         with self._lock:
-            self._cache_value(key, value)
             super().set(key, value)
+            self._cache_value(key, value)
+
 
     def mget(self, keys):
         if not keys:
             return
-        return [(key, self.get(key)) for key in keys]
+        for key in keys:
+            value = self.get(key)
+            if value:
+                yield key, value

--- a/constance/backends/redisd.py
+++ b/constance/backends/redisd.py
@@ -1,9 +1,11 @@
+from pickle import loads, dumps
+from threading import Lock
+from time import monotonic
+
 from django.core.exceptions import ImproperlyConfigured
 
 from . import Backend
 from .. import settings, utils, signals, config
-
-from pickle import loads, dumps
 
 
 class RedisBackend(Backend):
@@ -48,3 +50,41 @@ class RedisBackend(Backend):
         signals.config_updated.send(
             sender=config, key=key, old_value=old_value, new_value=value
         )
+
+
+class CachingRedisBackend(RedisBackend):
+    _sentinel = object()
+    _lock = Lock()
+
+    def __init__(self):
+        super().__init__()
+        self._timeout = settings.REDIS_CACHE_TIMEOUT
+        self._cache = {}
+        self._sentinel = object()
+
+    def _has_expired(self, value):
+        return value[0] <= monotonic()
+
+    def _cache_value(self, key, new_value):
+        self._cache[key] = (monotonic() + self._timeout, new_value)
+
+    def get(self, key):
+        value = self._cache.get(key, self._sentinel)
+
+        if value is self._sentinel or self._has_expired(value):
+            with self._lock:
+                new_value = super().get(key)
+                self._cache_value(key, new_value)
+                return new_value
+
+        return value[1]
+
+    def set(self, key, value):
+        with self._lock:
+            self._cache_value(key, value)
+            super().set(key, value)
+
+    def mget(self, keys):
+        if not keys:
+            return
+        return [(key, self.get(key)) for key in keys]

--- a/constance/settings.py
+++ b/constance/settings.py
@@ -30,6 +30,8 @@ DATABASE_PREFIX = getattr(settings, 'CONSTANCE_DATABASE_PREFIX', '')
 
 REDIS_PREFIX = getattr(settings, 'CONSTANCE_REDIS_PREFIX', 'constance:')
 
+REDIS_CACHE_TIMEOUT = getattr(settings, 'CONSTANCE_REDIS_CACHE_TIMEOUT', 60)
+
 REDIS_CONNECTION_CLASS = getattr(
     settings,
     'CONSTANCE_REDIS_CONNECTION_CLASS',

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -23,6 +23,14 @@ to add it to your project settings::
 
     CONSTANCE_BACKEND = 'constance.backends.redisd.RedisBackend'
 
+Default redis backend retrieves values every time. There is another redis backend with local cache.
+`CachingRedisBackend` stores the value from a redis to memory at first access and checks a value ttl at next.
+Configuration installation is simple::
+
+    CONSTANCE_BACKEND = 'constance.backends.redisd.CachingRedisBackend'
+    # optionally set a value ttl
+    CONSTANCE_REDIS_CACHE_TIMEOUT = 60
+
 .. _`redis-py`: https://pypi.python.org/pypi/redis
 
 Settings
@@ -76,6 +84,12 @@ objects when storing in the Redis database. Defaults to ``pickle.DEFAULT_PROTOCO
 
 You might want to pin this value to a specific protocol number, since ``pickle.DEFAULT_PROTOCOL``
 means different things between versions of Python.
+
+``CONSTANCE_REDIS_CACHE_TIMEOUT``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The (optional) ttl of values in seconds used by `CachingRedisBackend` for storing in a local cache.
+Defaults to `60` seconds.
 
 Database
 --------

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -7,12 +7,19 @@ from tests.storage import StorageTestsMixin
 
 class TestRedis(StorageTestsMixin, TestCase):
 
+    _BACKEND = 'constance.backends.redisd.RedisBackend'
+
     def setUp(self):
         self.old_backend = settings.BACKEND
-        settings.BACKEND = 'constance.backends.redisd.RedisBackend'
+        settings.BACKEND = self._BACKEND
         super().setUp()
         self.config._backend._rd.clear()
 
     def tearDown(self):
         self.config._backend._rd.clear()
         settings.BACKEND = self.old_backend
+
+
+class TestCachingRedis(TestRedis):
+
+    _BACKEND = 'constance.backends.redisd.CachingRedisBackend'


### PR DESCRIPTION
Quite often configuration is a rarely updated. And get current value in time is not so important. But redis backend always retrieves a current value.
Due to this simple access to the config has a sudden overhead especially in cycles. Programmer should always remeber about it and cache values manually.
Even a small timeout can drastically increase performance.