### PR TITLE
Serialize fields according to widget

### DIFF
--- a/example/cheeseshop/fields.py
+++ b/example/cheeseshop/fields.py
@@ -1,0 +1,24 @@
+import json
+from django.forms import fields, widgets
+
+
+class JsonField(fields.CharField):
+    widget = widgets.Textarea
+
+    def __init__(self, rows: int = 5, **kwargs):
+        self.rows = rows
+        super().__init__(**kwargs)
+
+    def widget_attrs(self, widget: widgets.Widget):
+        attrs = super().widget_attrs(widget)
+        attrs['rows'] = self.rows
+        return attrs
+
+    def to_python(self, value):
+        if value:
+            return json.loads(value)
+        else:
+            return {}
+
+    def prepare_value(self, value):
+        return json.dumps(value)

--- a/example/cheeseshop/settings.py
+++ b/example/cheeseshop/settings.py
@@ -102,6 +102,7 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         }
     ],
     'email': ('django.forms.fields.EmailField',),
+    'json_field': ['cheeseshop.fields.JsonField']
 }
 
 CONSTANCE_CONFIG = {
@@ -112,6 +113,11 @@ CONSTANCE_CONFIG = {
     'DATE_ESTABLISHED': (date(1972, 11, 30), "the shop's first opening"),
     'MY_SELECT_KEY': ('yes', 'select yes or no', 'yes_no_null_select'),
     'MULTILINE': ('Line one\nLine two', 'multiline string'),
+    'JSON_DATA': (
+        {'a': 1_000, 'b': 'test', 'max': 30_000_000},
+        'Some test data for json',
+        'json_field',
+    ),
 }
 
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'


### PR DESCRIPTION
Default value of custom fields does not work properly with custom fields. 
For example, if i use json field like in my merge request, default value will be serialized with ordinary quotes and it is invalid json and i would not be able to reset to default. Actual value is serialized by from form and is always correct.