### PR TITLE
Fix build issues

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,4 +38,4 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    pypy3: pypy3
+    pypy-3: pypy3


### PR DESCRIPTION
Fix the error preventing pypy from publishing the package.

Implemented the error log suggestion:

```
WARNING: PendingDeprecationWarning
Support of old-style PyPy config keys will be removed in tox-gh-actions v3.
Please use "pypy-2" and "pypy-3" instead of "pypy2" and "pypy3".

Example of tox.ini:
[gh-actions]
python =
    pypy-2: pypy2
    pypy-3: pypy3
    # The followings won't work with tox-gh-actions v3
    # pypy2: pypy2
    # pypy3: pypy3
```

For more details:

 - Successful build: https://github.com/pirods/django-constance/runs/6074844048?check_suite_focus=true
 - Failing build: https://github.com/jazzband/django-constance/runs/5676961960?check_suite_focus=true

  Issue #468
