### PR TITLE
Add support for using gettext in fieldset headers

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -276,8 +276,13 @@ class ConstanceAdmin(admin.ModelAdmin):
             )
 
         if settings.CONFIG_FIELDSETS:
+            if isinstance(settings.CONFIG_FIELDSETS, dict):
+                fieldset_items = settings.CONFIG_FIELDSETS.items()
+            else:
+                fieldset_items = settings.CONFIG_FIELDSETS
+
             context['fieldsets'] = []
-            for fieldset_title, fieldset_data in settings.CONFIG_FIELDSETS.items():
+            for fieldset_title, fieldset_data in fieldset_items:
                 if type(fieldset_data) == dict:
                     fields_list = fieldset_data['fields']
                     collapse = fieldset_data.get('collapse', False)

--- a/constance/admin.py
+++ b/constance/admin.py
@@ -312,7 +312,7 @@ class ConstanceAdmin(admin.ModelAdmin):
                 if collapse:
                     fieldset_context['collapse'] = True
                 context['fieldsets'].append(fieldset_context)
-            if not isinstance(settings.CONFIG_FIELDSETS, OrderedDict):
+            if not isinstance(settings.CONFIG_FIELDSETS, (OrderedDict, tuple)):
                 context['fieldsets'].sort(key=itemgetter('title'))
 
         if not isinstance(settings.CONFIG, OrderedDict):

--- a/constance/checks.py
+++ b/constance/checks.py
@@ -35,8 +35,13 @@ def get_inconsistent_fieldnames():
     """
     from . import settings
 
+    if isinstance(settings.CONFIG_FIELDSETS, dict):
+        fieldset_items = settings.CONFIG_FIELDSETS.items()
+    else:
+        fieldset_items = settings.CONFIG_FIELDSETS
+
     field_name_list = []
-    for fieldset_title, fields_list in settings.CONFIG_FIELDSETS.items():
+    for fieldset_title, fields_list in fieldset_items:
         # fields_list can be a dictionary, when a fieldset is defined as collapsible
         # https://django-constance.readthedocs.io/en/latest/#fieldsets-collapsing
         if isinstance(fields_list, dict) and 'fields' in fields_list:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -216,6 +216,36 @@ To make some fieldsets collapsing you can use new format in CONSTANCE_CONFIG_FIE
             'Theme Options': ('THEME',),
         }
 
+Field internationalization
+--------------------------
+
+Field description and fieldset headers can be integrated into Django's
+internationalization using the ``gettext_lazy`` function. Note that the
+``CONSTANCE_CONFIG_FIELDSETS`` must be converted to a tuple instead of dict
+as it is not possible to have lazy proxy objects as dictionary keys in the
+settings file. Example:
+
+.. code-block:: python
+
+        from django.utils.translation import gettext_lazy as _
+
+        CONSTANCE_CONFIG = {
+            'SITE_NAME': ('My Title', _('Website title')),
+            'SITE_DESCRIPTION': ('', _('Website description')),
+            'THEME': ('light-blue', _('Website theme')),
+        }
+
+        CONSTANCE_CONFIG_FIELDSETS = (
+            (
+                _('General Options'),
+                {
+                    'fields': ('SITE_NAME', 'SITE_DESCRIPTION'),
+                    'collapse': True,
+                },
+            ),
+            (_('Theme Options'), ('THEME',)),
+        )
+
 Usage
 -----
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -77,6 +77,18 @@ class TestAdmin(TestCase):
         self.assertContains(response, '<h2>Numbers</h2>')
         self.assertContains(response, '<h2>Text</h2>')
 
+    @mock.patch('constance.settings.CONFIG_FIELDSETS', (
+        ('Numbers', ('INT_VALUE',)),
+        ('Text', ('STRING_VALUE',)),
+    ))
+    def test_fieldset_tuple(self):
+        self.client.login(username='admin', password='nimda')
+        request = self.rf.get('/admin/constance/config/')
+        request.user = self.superuser
+        response = self.options.changelist_view(request, {})
+        self.assertContains(response, '<h2>Numbers</h2>')
+        self.assertContains(response, '<h2>Text</h2>')
+
     @mock.patch('constance.settings.CONFIG_FIELDSETS', {
         'Numbers': {
             'fields': ('INT_VALUE', 'DECIMAL_VALUE',),


### PR DESCRIPTION
Suggested fix for #488 

A simple fix that adds support for using a tuple instead of a dictionary for `CONSTANCE_CONFIG_FIELDSETS`. This avoids the need to hash the fieldset header and therefore allows using the `gettext_lazy` function for them. 

---

Along the change itself, I've also included a test and an update to the documentation. 