### PR TITLE
Add official support for Django 4.2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,9 +5,11 @@ v3.0.0 (future)
 ~~~~~~~~~~~~~~~~~~~
 
 * Refactor database backend
-Backward incompatible changes:
-remove 'constance.backends.database' from INSTALLED_APPS
+  Backward incompatible changes:
+  remove ``'constance.backends.database'`` from ``INSTALLED_APPS``
+
 * Dropped support for python < 3.7 and django < 3.2
+
 * Example app now supports django 4.1
 
 v2.10.0 (unreleased)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ v3.0.0 (future)
 
 * Example app now supports django 4.1
 
+* Add support for django 4.2
+
 v2.10.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
 envlist =
     py{37,38,39,310,py3}-dj{32}-{unittest,pytest}
     py{38,39,310}-dj{40}-{unittest,pytest}
-    py{38,39,310,311}-dj{41}-{unittest,pytest}
+    py{38,39,310,311}-dj{41,42}-{unittest,pytest}
     py{310,311}-dj{main}-{unittest,pytest}
 
 [testenv]
@@ -15,6 +15,7 @@ deps =
     dj32: Django>=3.2,<4
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest: pytest
     pytest: pytest-cov


### PR DESCRIPTION
For supported versions of Python: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django

