### PR TITLE
remove pypy from tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox<4
 envlist =
-    py{37,38,39,310,py3}-dj{32}-{unittest,pytest}
+    py{37,38,39,310}-dj{32}-{unittest,pytest}
     py{38,39,310}-dj{40}-{unittest,pytest}
     py{38,39,310,311}-dj{41,42}-{unittest,pytest}
     py{310,311}-dj{main}-{unittest,pytest}
@@ -12,7 +12,7 @@ deps =
     redis
     coverage
     django-picklefield
-    dj32: Django>=3.2,<4
+    dj32: Django>=3.2,<4;
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<5.0
@@ -39,4 +39,3 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy-3: pypy3


### PR DESCRIPTION
There is an issue with typings in pypi.
asgiref (django dependency) has been recently updated to version 3.7.2 [changelog](https://github.com/django/asgiref/blob/main/CHANGELOG.txt) and there are new typings.
I don`t want to pin asgiref version to 3.7.1 because this is test case for django 3.2. New django versions are not tested on pypy and it is better to use the latest asgiref.