### PR TITLE
allow the OperationalError to be raised

### DIFF
--- a/constance/backends/database.py
+++ b/constance/backends/database.py
@@ -78,7 +78,7 @@ class DatabaseBackend(Backend):
         if value is None:
             try:
                 value = self._model._default_manager.get(key=key).value
-            except (OperationalError, ProgrammingError, self._model.DoesNotExist):
+            except (ProgrammingError, self._model.DoesNotExist):
                 pass
             else:
                 if self._cache:

--- a/tests/backends/test_database.py
+++ b/tests/backends/test_database.py
@@ -1,6 +1,10 @@
+from unittest.mock import MagicMock
+
+from django.db.utils import OperationalError, ProgrammingError
 from django.test import TestCase
 
 from constance import settings
+from constance.backends.database import DatabaseBackend
 from tests.storage import StorageTestsMixin
 
 
@@ -23,6 +27,27 @@ class TestDatabase(StorageTestsMixin, TestCase):
         # Set value
         with self.assertNumQueries(2):
             self.config.INT_VALUE = 15
+
+    def test_model_does_not_exist_error_does_not_raise(self):
+        backend = DatabaseBackend()
+        original_get = backend._model._default_manager.get
+        backend._model._default_manager.get = MagicMock(side_effect=backend._model.DoesNotExist)
+        self.assertIsNone(backend.get('does_not_exist'))
+        backend._model._default_manager.get = original_get
+
+    def test_operational_error_is_raised(self):
+        backend = DatabaseBackend()
+        original_get = backend._model._default_manager.get
+        backend._model._default_manager.get = MagicMock(side_effect=OperationalError)
+        self.assertRaises(OperationalError, backend.get, 'does_not_exist')
+        backend._model._default_manager.get = original_get
+
+    def test_programming_error_does_not_raise(self):
+        backend = DatabaseBackend()
+        original_get = backend._model._default_manager.get
+        backend._model._default_manager.get = MagicMock(side_effect=ProgrammingError)
+        self.assertIsNone(backend.get('does_not_exist'))
+        backend._model._default_manager.get = original_get
 
     def tearDown(self):
         settings.BACKEND = self.old_backend


### PR DESCRIPTION
when trying to get a value while there is no database connection, the OperationalError will be raised. We should allow it to be raised instead of suppressing it.

Related to https://github.com/jazzband/django-constance/issues/510