### PR TITLE
chore: update supported versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(ci): "
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,29 +9,16 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11'] # '3.12' does not work with tox@3
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-    - name: Cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-v1-
+        cache: 'pip'
 
     - name: Install dependencies
       run: |
@@ -43,6 +30,6 @@ jobs:
         tox -v
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         name: Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@ def find_version(*file_paths):
                               version_file, re.M)
     if version_match:
         return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
+    raise RuntimeError('Unable to find version string.')
 
 
 setup(
     name='django-constance',
-    version=find_version("constance", "__init__.py"),
-    url="https://github.com/jazzband/django-constance",
+    version=find_version('constance', '__init__.py'),
+    url='https://github.com/jazzband/django-constance',
     description='Django live settings with pluggable backends, including Redis.',
     long_description=read('README.rst'),
     author='Jannis Leidel',
@@ -34,30 +34,26 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',
     ],
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         'django-picklefield',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,20 +2,18 @@
 requires =
     tox<4
 envlist =
-    py{37,38,39,310}-dj{32}-{unittest,pytest}
-    py{38,39,310}-dj{40}-{unittest,pytest}
-    py{38,39,310,311}-dj{41,42}-{unittest,pytest}
-    py{310,311}-dj{main}-{unittest,pytest}
+    py{38,39,310,311,312}-dj{42}-{unittest,pytest}
+    py{310,311,312}-dj{50}-{unittest,pytest}
+    py{310,311,312}-dj{main}-{unittest,pytest}
 
 [testenv]
 deps =
     redis
     coverage
     django-picklefield
-    dj32: Django>=3.2,<4;
-    dj40: Django>=4.0,<4.1
-    dj41: Django>=4.1,<4.2
-    dj42: Django>=4.2,<5.0
+    dj42: django>=4.2,<4.3
+    dj50: django>=5.0,<5.1
+    dj51: django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest: pytest
     pytest: pytest-cov
@@ -34,8 +32,8 @@ setenv =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312


### PR DESCRIPTION
## Changes

- drop eol django 3.2 4.0 4.1
- drop eol python 3.7
- drop untested PyPy support
- prepare python 3.12 test
- prepare django 5.1 test
- update GH action dependencies
- add dependabot to maintain GH action dependencies

## Reference

fixes #540