### PR TITLE
Check missing migrations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 isolated_build = true
 envlist =
-    py{38,39,310,311,312}-dj{42}-{unittest,pytest}
-    py{310,311,312}-dj{50}-{unittest,pytest}
-    py{310,311,312}-dj{main}-{unittest,pytest}
+    py{38,39,310,311,312}-dj{42}-{unittest,pytest,checkmigrations}
+    py{310,311,312}-dj{50}-{unittest,pytest,checkmigrations}
+    py{310,311,312}-dj{main}-{unittest,pytest,checkmigrations}
 skip_missing_interpreters = True
 
 [testenv]
@@ -25,6 +25,7 @@ commands =
     unittest: coverage report
     unittest: coverage xml
     pytest: pytest --cov=. --ignore=.tox --disable-pytest-warnings --cov-report=xml --cov-append {toxinidir}
+    checkmigrations: django-admin makemigrations --check --dry-run
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONDONTWRITEBYTECODE = 1


### PR DESCRIPTION
Add a check to ensure migrations always reflect the latest changes of `models.py`.

As discussed in #570; feel free to cherry-pick into #571.