### PR TITLE
fix: Fixed _pickle.UnpicklingError

### DIFF
--- a/constance/migrations/0003_drop_pickle.py
+++ b/constance/migrations/0003_drop_pickle.py
@@ -40,7 +40,10 @@ def migrate_pickled_data(apps, schema_editor) -> None:  # pragma: no cover
             prefixed_key = f'{_prefix}{key}'
             value = _rd.get(prefixed_key)
             if value is not None:
-                redis_migrated_data[prefixed_key] = dumps(pickle.loads(value))  # noqa: S301
+                try:
+                    redis_migrated_data[prefixed_key] = dumps(pickle.loads(value))  # noqa: S301
+                except pickle.UnpicklingError:
+                    continue
         for prefixed_key, value in redis_migrated_data.items():
             _rd.set(prefixed_key, value)
 


### PR DESCRIPTION
Error Details
The migration process attempted to apply the migration 0003_drop_pickle but failed with the following traceback:

```bash
Operations to perform:
  Target specific migration: 0003_drop_pickle, from constance
Running migrations:
  Applying constance.0003_drop_pickle...Traceback (most recent call last):
  File "/code/manage.py", line 23, in <module>
    main()
  File "/code/manage.py", line 19, in main
    execute_from_command_line(sys.argv)
  File "/code/.venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/code/.venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/code/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/code/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 107, in wrapper
    res = handle_func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/.venv/lib/python3.12/site-packages/django/core/management/commands/migrate.py", line 357, in handle
    post_migrate_state = executor.migrate(
                         ^^^^^^^^^^^^^^^^^
  File "/code/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 135, in migrate
    state = self._migrate_all_forwards(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
    state = self.apply_migration(
            ^^^^^^^^^^^^^^^^^^^^^
  File "/code/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 255, in apply_migration
    state = migration.apply(state, schema_editor)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/.venv/lib/python3.12/site-packages/django/db/migrations/migration.py", line 132, in apply
    operation.database_forwards(
  File "/code/.venv/lib/python3.12/site-packages/django/db/migrations/operations/special.py", line 196, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/code/.venv/lib/python3.12/site-packages/constance/migrations/0003_drop_pickle.py", line 43, in migrate_pickled_data
    print(pickle.loads(value))
          ^^^^^^^^^^^^^^^^^^^
_pickle.UnpicklingError: invalid load key, '{'.
```