### PR TITLE
Fix Admin on Django 5.2

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -169,6 +169,7 @@ class Config:
         verbose_name_plural = _('config')
         abstract = False
         swapped = False
+        is_composite_pk = False
 
         def get_ordered_objects(self):
             return False


### PR DESCRIPTION
Early testing the [upgrade to Django 5.2](https://docs.djangoproject.com/en/dev/releases/5.2/), I'm facing an issue with Django-constance admin:
```
  File "/home/runner/work/silvr-app/silvr-app/silvr-app/.venv/lib/python3.12/site-packages/constance/admin.py", line 194, in <module>
    admin.site.register([Config], ConstanceAdmin)
  File "/home/runner/work/silvr-app/silvr-app/silvr-app/.venv/lib/python3.12/site-packages/django/contrib/admin/sites.py", line 116, in register
    if model._meta.is_composite_pk:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Meta' object has no attribute 'is_composite_pk'
```
Indeed, Django last/next version provides [composite primary keys](https://docs.djangoproject.com/en/dev/releases/5.2/#composite-primary-keys) which requires a new Meta on Models.
Due to the fake `Config` model django Constance is using, we need to do likes for other properties and hardcode it on the Config.