### PR TITLE
Extension of documentation for list and dict typed fields

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,6 +105,10 @@ The supported types are:
 * ``list``
 * ``dict``
 
+.. note::
+    To be able to use ``list`` and ``dict`` you need to set a widget and form field for these types as it is ambiguous what types shall be stored in the collection object.
+    You can do so with :setting:`CONSTANCE_ADDITIONAL_FIELDS` as explained below.
+
 For example, to force a value to be handled as a string:
 
 .. code-block:: python
@@ -164,6 +168,21 @@ Images and files are uploaded to ``MEDIA_ROOT`` by default. You can specify a su
         CONSTANCE_FILE_ROOT = 'constance'
 
 This will result in files being placed in ``media/constance`` within your ``BASE_DIR``. You can use deeper nesting in this setting (e.g. ``constance/images``) but other relative path components (e.g. ``../``) will be rejected.
+
+In case you want to store a list of ``int`` values in the constance config, a working setup is
+
+.. code-block:: python
+    
+    CONSTANCE_ADDITIONAL_FIELDS = {
+        list: ["django.forms.fields.JSONField", {"widget": "django.forms.Textarea"}],
+    }
+
+    CONSTANCE_CONFIG = {
+        'KEY': ([0, 10, 20], 'A list of integers', list),
+    }
+
+Make sure to use the ``JSONField`` for this purpose as user input in the admin page may be understood and saved as ``str`` otherwise.
+
 
 Ordered Fields in Django Admin
 ------------------------------


### PR DESCRIPTION
### Description

This PR adds a bit of documentation around the subject of using list and dict typed fields in constance. The goal is to clarify what is required to use these types successfully.
Additionally, while writing this I noticed two syntactically wrong :setting: tags in the existing docs and fixed them in another commit.

### Motivation

There have been multiple issues touching on this topic ( https://github.com/jazzband/django-constance/issues/620, https://github.com/jazzband/django-constance/issues/598, https://github.com/jazzband/django-constance/issues/574 ). I have struggled with the missing clarity on how to correctly use list and dicts with constance myself but have recently figured out how to do so. With this PR I want to move that info from being sprinkled throughout the issues into the docs, making users aware of how to configure constance correctly right out of the gate.

_Please get back to me if there is any need for clarification!_