### PR TITLE
Add Django 5.1 and 5.2 support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,7 +16,7 @@ v4.0.0 (2024/08/21)
 * Migrate JavaScript to ES2015
 * Fix documentation build
 * Add linters and formatters (using `ruff`)
-* Prepare for Django 5.1 support
+* Add support for Django 5.1 and 5.2
 * Migrate from `setup.py` to `pyproject.toml`
 * Bump `tox`
 * Declare support for Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",


### PR DESCRIPTION
Add official support for Django 5.1 and 5.2 versions.

- Add Django 5.1 and 5.2 classifiers to pyproject.toml
- Update changelog to reflect Django 5.1 and 5.2 support