### PR TITLE
Added missing logic to reset multi select

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -1,3 +1,4 @@
+import json
 from collections import OrderedDict
 from datetime import date
 from datetime import datetime
@@ -62,8 +63,13 @@ class ConstanceAdmin(admin.ModelAdmin):
             "is_date": isinstance(default, date),
             "is_datetime": isinstance(default, datetime),
             "is_checkbox": isinstance(form_field.field.widget, forms.CheckboxInput),
+            "is_multi_select": isinstance(
+                form_field.field.widget, (forms.SelectMultiple, forms.CheckboxSelectMultiple)
+            ),
             "is_file": isinstance(form_field.field.widget, forms.FileInput),
         }
+        if config_value["is_multi_select"]:
+            config_value["json_default"] = json.dumps(default if isinstance(default, list) else [default])
         if field_type and field_type in settings.ADDITIONAL_FIELDS:
             serialized_default = form[name].field.prepare_value(default)
             config_value["default"] = serialized_default

--- a/constance/static/admin/js/constance.js
+++ b/constance/static/admin/js/constance.js
@@ -12,6 +12,17 @@
 
             if (fieldType === 'checkbox') {
                 field.prop('checked', this.dataset.default === 'true');
+            } else if (fieldType === 'multi-select') {
+                const defaults = JSON.parse(this.dataset.default);
+                const stringDefaults = defaults.map(function(v) { return String(v); });
+                // CheckboxSelectMultiple: individual checkboxes inside a wrapper
+                field.find('input[type="checkbox"]').each(function() {
+                    $(this).prop('checked', stringDefaults.indexOf($(this).val()) !== -1);
+                });
+                // SelectMultiple: <select multiple> element
+                field.find('option').each(function() {
+                    $(this).prop('selected', stringDefaults.indexOf($(this).val()) !== -1);
+                });
             } else if (fieldType === 'date') {
                 const defaultDate = new Date(this.dataset.default * 1000);
                 $('#' + this.dataset.fieldId).val(defaultDate.strftime(get_format('DATE_INPUT_FORMATS')[0]));

--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -31,12 +31,14 @@
                         data-field-id="{{ item.form_field.auto_id }}"
                         data-field-type="{% spaceless %}
                         {% if item.is_checkbox %}checkbox
+                        {% elif item.is_multi_select %}multi-select
                         {% elif item.is_datetime %}datetime
                         {% elif item.is_date %}date
                         {% endif %}
                         {% endspaceless %}"
                         data-default="{% spaceless %}
                         {% if item.is_checkbox %}{% if item.raw_default %} true {% else %} false {% endif %}
+                        {% elif item.is_multi_select %}{{ item.json_default }}
                         {% elif item.is_date %}{{ item.raw_default|date:"U" }}
                         {% elif item.is_datetime %}{{ item.raw_default|date:"U" }}
                         {% else %}{{ item.default }}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -266,6 +266,55 @@ class TestAdmin(TestCase):
         content_str = response.content.decode()
         self.assertGreater(content_str.find("STRING_VALUE"), content_str.find("INT_VALUE"))
 
+    @mock.patch(
+        "constance.settings.ADDITIONAL_FIELDS",
+        {
+            "language_select": [
+                "django.forms.fields.TypedMultipleChoiceField",
+                {
+                    "widget": "django.forms.CheckboxSelectMultiple",
+                    "choices": (("en", "English"), ("de", "German"), ("fr", "French")),
+                    "coerce": str,
+                },
+            ],
+        },
+    )
+    @mock.patch(
+        "constance.settings.CONFIG",
+        {
+            "LANGUAGES": (["en", "de"], "Supported languages", "language_select"),
+        },
+    )
+    def test_reset_to_default_multi_select(self):
+        """
+        Test that multi-select config values render with data-field-type='multi-select'
+        and a JSON-encoded data-default attribute.
+        """
+        # Re-parse additional fields so the mock is picked up by the form
+        from constance.forms import FIELDS, parse_additional_fields
+
+        FIELDS.update(parse_additional_fields({"language_select": [
+            "django.forms.fields.TypedMultipleChoiceField",
+            {
+                "widget": "django.forms.CheckboxSelectMultiple",
+                "choices": (("en", "English"), ("de", "German"), ("fr", "French")),
+                "coerce": str,
+            },
+        ]}))
+        try:
+            self.client.login(username="admin", password="nimda")
+            request = self.rf.get("/admin/constance/config/")
+            request.user = self.superuser
+            response = self.options.changelist_view(request, {})
+            response.render()
+            content = response.content.decode()
+
+            self.assertIn('data-field-type="multi-select"', content)
+            self.assertIn('data-default="[&quot;en&quot;, &quot;de&quot;]"', content)
+        finally:
+            # Clean up FIELDS to avoid leaking into other tests
+            FIELDS.pop("language_select", None)
+
     def test_labels(self):
         self.assertEqual(type(self.model._meta.label), str)
         self.assertEqual(type(self.model._meta.label_lower), str)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -291,16 +291,23 @@ class TestAdmin(TestCase):
         and a JSON-encoded data-default attribute.
         """
         # Re-parse additional fields so the mock is picked up by the form
-        from constance.forms import FIELDS, parse_additional_fields
+        from constance.forms import FIELDS
+        from constance.forms import parse_additional_fields
 
-        FIELDS.update(parse_additional_fields({"language_select": [
-            "django.forms.fields.TypedMultipleChoiceField",
-            {
-                "widget": "django.forms.CheckboxSelectMultiple",
-                "choices": (("en", "English"), ("de", "German"), ("fr", "French")),
-                "coerce": str,
-            },
-        ]}))
+        FIELDS.update(
+            parse_additional_fields(
+                {
+                    "language_select": [
+                        "django.forms.fields.TypedMultipleChoiceField",
+                        {
+                            "widget": "django.forms.CheckboxSelectMultiple",
+                            "choices": (("en", "English"), ("de", "German"), ("fr", "French")),
+                            "coerce": str,
+                        },
+                    ]
+                }
+            )
+        )
         try:
             self.client.login(username="admin", password="nimda")
             request = self.rf.get("/admin/constance/config/")


### PR DESCRIPTION
This is regarding the issue I described in #652 . I did a bit of digging and realized that the "Reset to default" button in the admin panel did not work for fields using CheckboxSelectMultiple or SelectMultiple widgets because the JS handler had no knowledge of multi-valued fields. It fell through to the generic field.val() branch, which set the Python repr string (e.g. ['val1', 'val2']) on a wrapper div, doing nothing.

## Changes

- constance/admin.py: Detect multi-select widgets (SelectMultiple, CheckboxSelectMultiple) via a new is_multi_select flag and serialize the default value as JSON
- constance.js: Add a multi-select handler that parses the JSON defaults and toggles the correct checkboxes/options
- results_list.html: Wire up data-field-type="multi-select" and data-default with the JSON-encoded default
- tests/test_admin.py: Add regression test verifying multi-select fields render the correct data attributes

@Mogost and @camilonova , could you have a look?