### PR TITLE
Remove idempotent autofill to fix lazy config load in async context

### DIFF
--- a/constance/backends/database.py
+++ b/constance/backends/database.py
@@ -40,7 +40,6 @@ class DatabaseBackend(Backend):
                 )
         else:
             self._cache = None
-        self.autofill()
         # Clear simple cache.
         post_save.connect(self.clear, sender=self._model)
 

--- a/tests/backends/test_database.py
+++ b/tests/backends/test_database.py
@@ -72,6 +72,11 @@ class TestDatabaseBackendConstruction(TestCase):
         with self.assertNumQueries(0):
             DatabaseBackend()
 
+    def test_autofill_is_noop_without_cache(self):
+        backend = DatabaseBackend()
+        with self.assertNumQueries(0):
+            backend.autofill()
+
     def test_backend_init_does_no_queries_with_cache(self):
         old_cache_backend = settings.DATABASE_CACHE_BACKEND
         settings.DATABASE_CACHE_BACKEND = "default"

--- a/tests/backends/test_database.py
+++ b/tests/backends/test_database.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 from django.test import TransactionTestCase
 
+from constance import LazyConfig
 from constance import settings
+from constance.backends.database import DatabaseBackend
 from constance.base import Config
 from tests.storage import StorageTestsMixin
 
@@ -56,11 +58,43 @@ class TestDatabaseWithCache(StorageTestsMixin, TestCase):
         settings.DATABASE_CACHE_BACKEND = self.old_cache_backend
 
 
+class TestDatabaseBackendConstruction(TestCase):
+    """Regression tests for #667: backend construction must not perform I/O."""
+
+    def setUp(self):
+        self.old_backend = settings.BACKEND
+        settings.BACKEND = "constance.backends.database.DatabaseBackend"
+
+    def tearDown(self):
+        settings.BACKEND = self.old_backend
+
+    def test_backend_init_does_no_queries(self):
+        with self.assertNumQueries(0):
+            DatabaseBackend()
+
+    def test_backend_init_does_no_queries_with_cache(self):
+        old_cache_backend = settings.DATABASE_CACHE_BACKEND
+        settings.DATABASE_CACHE_BACKEND = "default"
+        try:
+            with self.assertNumQueries(0):
+                DatabaseBackend()
+        finally:
+            settings.DATABASE_CACHE_BACKEND = old_cache_backend
+
+
 class TestDatabaseAsync(TransactionTestCase):
     def setUp(self):
         self.old_backend = settings.BACKEND
         settings.BACKEND = "constance.backends.database.DatabaseBackend"
         self.config = Config()
+
+    async def test_lazy_config_first_access_in_async(self):
+        # End-to-end: LazyConfig _setup() runs from inside the loop and the
+        # awaited value resolves. Companion to TestDatabaseBackendConstruction
+        # which is the strict #667 regression test.
+        lazy = LazyConfig()
+        value = await lazy.INT_VALUE
+        self.assertEqual(value, 1)
 
     def tearDown(self):
         settings.BACKEND = self.old_backend


### PR DESCRIPTION
Fixes #667: lazy access to `constance.config` from an async context raised `SynchronousOnlyOperation` because `DatabaseBackend.__init__` called `self.autofill()`, triggering a sync cache/DB read before `Config.__getattr__`'s async-aware branch could run.

The autofill call is removed from `__init__` — it's already invoked lazily on cache miss in `get()` and `aget()`, so the warm-up happens on first read instead of at backend construction. Same total I/O, just deferred.

## Tests

- New regression tests in `TestDatabaseBackendConstruction` assert `DatabaseBackend()` performs zero queries, with and without a cache backend configured. Verified to fail on master without the fix.
- New end-to-end test `test_lazy_config_first_access_in_async` exercises `await LazyConfig().INT_VALUE` from inside the event loop.